### PR TITLE
[Chore] JPA 및 DataSource Config 구성

### DIFF
--- a/src/main/java/com/hereeat/HereeatApplication.java
+++ b/src/main/java/com/hereeat/HereeatApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class HereeatApplication {
 
 	static void main(String[] args) {

--- a/src/main/java/com/hereeat/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/hereeat/global/common/entity/BaseEntity.java
@@ -1,5 +1,6 @@
 package com.hereeat.global.common.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,6 +22,7 @@ public class BaseEntity {
     private Long id;
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/com/hereeat/global/config/datasource/CoreDataSourceConfig.java
+++ b/src/main/java/com/hereeat/global/config/datasource/CoreDataSourceConfig.java
@@ -1,0 +1,26 @@
+package com.hereeat.global.config.datasource;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CoreDataSourceConfig { // Datasource / HikariCP
+
+    @Bean
+    @ConfigurationProperties(prefix = "datasource.db.core")
+    public HikariConfig coreHikariConfig() {
+        return new HikariConfig();
+    }
+
+    @Bean
+    public DataSource coreDataSource(
+            @Qualifier("coreHikariConfig") HikariConfig config
+    ) {
+        return new HikariDataSource(config);
+    }
+}

--- a/src/main/java/com/hereeat/global/config/jpa/CoreJpaConfig.java
+++ b/src/main/java/com/hereeat/global/config/jpa/CoreJpaConfig.java
@@ -1,0 +1,21 @@
+package com.hereeat.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@EntityScan(
+        basePackages = {
+                "com.hereeat"
+        }
+)
+@EnableJpaRepositories(
+        basePackages = {
+                "com.hereeat"
+        }
+)
+public class CoreJpaConfig { // JPA + Transaction + Repository
+}

--- a/src/main/java/com/hereeat/global/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/hereeat/global/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.hereeat.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig { // Auditing
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,22 @@ spring:
   application:
     name: hereeat
 
+datasource:
+  db:
+    core:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: ${DATASOURCE_DB_CORE_JDBC_URL}
+      username: ${DATASOURCE_DB_CORE_USERNAME}
+      password: ${DATASOURCE_DB_CORE_PASSWORD}
+      pool-name: core-db-pool
+      maximum-pool-size: 10
+      connection-timeout: 1500
+      keepalive-time: 30000
+      validation-timeout: 1000
+      max-lifetime: 600000
+      data-source-properties:
+        rewriteBatchedStatements: true
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 🌱 관련 이슈

- close #9 

## 📌 작업 내용

- JPA 및 DataSource 설정 구성
- **CoreJpaConfig**: JPA, Transaction, Repository 관리
  - `@EnableTransactionManagement`: 트랜잭션 관리 활성화
  - `@EntityScan`: 엔티티 스캔 범위 설정 (`com.hereeat`)
  - `@EnableJpaRepositories`: 리포지토리 스캔 범위 설정
  
- **CoreDataSourceConfig**: HikariCP 기반 DataSource 설정
  - `@ConfigurationProperties`로 yaml 설정 바인딩
  - HikariCP를 통한 커넥션 풀 관리
  
- **JpaAuditingConfig**: Auditing 기능 분리
  - `@EnableJpaAuditing`으로 엔티티 생성/수정 시각 자동 관리

- **application.yaml**: PostgreSQL DataSource 구성
  - HikariCP 설정: pool-name, maximum-pool-size(10), connection-timeout 등
  - `rewriteBatchedStatements: true`로 배치 성능 최적화

## 📝 참고

- 서비스명 영문 표기법 변경(hereeat → yogieat)에 따라, CoreJpaConfig 내 basePackages 경로도 변경 예정

## 💬 리뷰 요구사항(선택)

-