### PR TITLE
[Chore] yaml 역할, 환경 분리

### DIFF
--- a/src/main/resources/ai.yaml
+++ b/src/main/resources/ai.yaml
@@ -1,0 +1,4 @@
+ai:
+  gemini:
+    api-key: ${AI_GEMINI_API_KEY}
+    model: ${AI_GEMINI_MODEL:gemini-2.5-flash}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,48 +1,20 @@
 spring:
+  threads:
+    virtual:
+      enabled: true
   application:
     name: yogieat
   config:
     import:
       - logging.yaml
+      - datasource.yaml
+      - monitoring.yaml
+      - ai.yaml
   web.resources.add-mappings: false
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        show_log: true
-        format_sql: true
 
-datasource:
-  db:
-    core:
-      driver-class-name: org.postgresql.Driver
-      jdbc-url: ${DATASOURCE_DB_CORE_JDBC_URL}
-      username: ${DATASOURCE_DB_CORE_USERNAME}
-      password: ${DATASOURCE_DB_CORE_PASSWORD}
-      pool-name: core-db-pool
-      maximum-pool-size: 10
-      connection-timeout: 1500
-      keepalive-time: 30000
-      validation-timeout: 1000
-      max-lifetime: 600000
-      data-source-properties:
-        rewriteBatchedStatements: true
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-      base-path: /actuator
-    jmx:
-      exposure:
-        exclude: "*"
-  health:
-    defaults:
-      enabled: true
-
-ai:
-  gemini:
-    api-key: ${AI_GEMINI_API_KEY}
-    model: ${AI_GEMINI_MODEL:gemini-2.5-flash}
+server:
+  tomcat:
+    max-connections: 20000
+    threads:
+      max: 600
+      min-spare: 100

--- a/src/main/resources/datasource.yaml
+++ b/src/main/resources/datasource.yaml
@@ -1,0 +1,114 @@
+spring:
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        default_batch_fetch_size: 100
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  jpa:
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+datasource:
+  db:
+    core:
+      driver-class-name: org.h2.Driver
+      jdbc-url: jdbc:h2:mem:core;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+      username: sa
+      password: ""
+      pool-name: core-db-pool
+      maximum-pool-size: 5
+      data-source-properties:
+        rewriteBatchedStatements: true
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_log: true
+        format_sql: true
+datasource:
+  db:
+    core:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: ${DATASOURCE_DB_CORE_JDBC_URL}
+      username: ${DATASOURCE_DB_CORE_USERNAME}
+      password: ${DATASOURCE_DB_CORE_PASSWORD}
+      pool-name: core-db-pool
+      maximum-pool-size: 10
+      connection-timeout: 1500
+      keepalive-time: 30000
+      validation-timeout: 1000
+      max-lifetime: 600000
+      data-source-properties:
+        rewriteBatchedStatements: true
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_log: true
+        format_sql: true
+datasource:
+  db:
+    core:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: ${DATASOURCE_DB_CORE_JDBC_URL}
+      username: ${DATASOURCE_DB_CORE_USERNAME}
+      password: ${DATASOURCE_DB_CORE_PASSWORD}
+      pool-name: core-db-pool
+      maximum-pool-size: 5
+      connection-timeout: 1500
+      keepalive-time: 30000
+      validation-timeout: 1000
+      max-lifetime: 600000
+      data-source-properties:
+        rewriteBatchedStatements: true
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  jpa:
+    hibernate:
+      ddl-auto: update # TODO: 추후 prod 배포 후 해당 환경에서는 none으로 변경 필요
+    properties:
+      hibernate:
+        show_log: true
+datasource:
+  db:
+    core:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: ${DATASOURCE_DB_CORE_JDBC_URL}
+      username: ${DATASOURCE_DB_CORE_USERNAME}
+      password: ${DATASOURCE_DB_CORE_PASSWORD}
+      pool-name: core-db-pool
+      maximum-pool-size: 10
+      connection-timeout: 1500
+      keepalive-time: 30000
+      validation-timeout: 1000
+      max-lifetime: 600000
+      data-source-properties:
+        rewriteBatchedStatements: true

--- a/src/main/resources/monitoring.yaml
+++ b/src/main/resources/monitoring.yaml
@@ -1,0 +1,12 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+      base-path: /actuator
+    jmx:
+      exposure:
+        exclude: "*"
+  health:
+    defaults:
+      enabled: true


### PR DESCRIPTION
## 🌱 관련 이슈

- close #33 

## 📌 작업 내용

- yaml을 역할에 맞게 분리
- datasource 같은 경우 환경에 맞게 분리

## 📝 참고

- 잠수함 패치로 이전 Java 21 버전에서 virtual thread가 pinning 이슈로 지양하였지만, 이번 25에서는 해결되었기에 추가하였습니다! 
- 자유롭게 의견주셔도 됩니당

## 💬 리뷰 요구사항(선택)

-