### PR TITLE
[Feature] 모임 참여 API & 참여에 대한 동시성 LockManager

### DIFF
--- a/src/main/java/com/yogieat/domain/gathering/domain/Gathering.java
+++ b/src/main/java/com/yogieat/domain/gathering/domain/Gathering.java
@@ -3,6 +3,7 @@ package com.yogieat.domain.gathering.domain;
 import com.yogieat.domain.common.Place;
 import com.yogieat.domain.gathering.domain.value.TimeSlot;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record Gathering(
         Long id,
@@ -11,6 +12,10 @@ public record Gathering(
         LocalDate scheduledDate,
         TimeSlot timeSlot,
         Place place,
-        Integer headCount
+        Integer headCount,
+        LocalDateTime deletedAt
 ) {
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
 }

--- a/src/main/java/com/yogieat/domain/gathering/entity/GatheringEntity.java
+++ b/src/main/java/com/yogieat/domain/gathering/entity/GatheringEntity.java
@@ -64,7 +64,8 @@ public class GatheringEntity extends BaseEntity {
                 entity.getScheduledDate(),
                 entity.getTimeSlot(),
                 entity.getPlace(),
-                entity.getHeadCount()
+                entity.getHeadCount(),
+                entity.getDeletedAt()
         );
     }
 }

--- a/src/main/java/com/yogieat/domain/gathering/repository/GatheringCoreRepository.java
+++ b/src/main/java/com/yogieat/domain/gathering/repository/GatheringCoreRepository.java
@@ -1,6 +1,9 @@
 package com.yogieat.domain.gathering.repository;
 
+import com.yogieat.domain.gathering.domain.Gathering;
+import com.yogieat.domain.gathering.entity.GatheringEntity;
 import com.yogieat.domain.gathering.service.GatheringRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +11,10 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class GatheringCoreRepository implements GatheringRepository {
     private final GatheringJpaRepository gatheringJpaRepository;
+
+    @Override
+    public Optional<Gathering> findById(Long id) {
+        return gatheringJpaRepository.findById(id)
+                .map(GatheringEntity::toDomain);
+    }
 }

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringRepository.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringRepository.java
@@ -1,4 +1,8 @@
 package com.yogieat.domain.gathering.service;
 
+import com.yogieat.domain.gathering.domain.Gathering;
+import java.util.Optional;
+
 public interface GatheringRepository {
+    Optional<Gathering> findById(Long id);
 }

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
@@ -1,10 +1,33 @@
 package com.yogieat.domain.gathering.service;
 
+import com.yogieat.domain.gathering.domain.Gathering;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class GatheringService {
-    private final GatheringRepository gatheringRepository;
+    private final GatheringValidator gatheringValidator;
+
+    /**
+     * Gathering 존재 여부 및 삭제 여부 검증
+     * GatheringValidator에게 위임
+     *
+     * @param gatheringId 검증할 모임 ID
+     * @return 검증된 Gathering 도메인
+     */
+    public Gathering validateGatheringExists(Long gatheringId) {
+        return gatheringValidator.validateGatheringExists(gatheringId);
+    }
+
+    /**
+     * Gathering 참여 인원이 가득 찼는지 검증
+     * GatheringValidator에게 위임
+     *
+     * @param gathering 검증할 모임
+     * @param currentParticipantCount 현재 참여자 수
+     */
+    public void validateGatheringNotFull(Gathering gathering, long currentParticipantCount) {
+        gatheringValidator.validateGatheringNotFull(gathering, currentParticipantCount);
+    }
 }

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringValidator.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringValidator.java
@@ -1,0 +1,48 @@
+package com.yogieat.domain.gathering.service;
+
+import com.yogieat.domain.gathering.domain.Gathering;
+import com.yogieat.global.error.CustomException;
+import com.yogieat.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Gathering 관련 검증 컴포넌트
+ */
+@Component
+@RequiredArgsConstructor
+public class GatheringValidator {
+    private final GatheringRepository gatheringRepository;
+
+    /**
+     * Gathering 존재 여부 및 삭제 여부 검증
+     *
+     * @param gatheringId 검증할 모임 ID
+     * @return 검증된 Gathering 도메인
+     * @throws CustomException GATHERING_NOT_FOUND - 모임이 존재하지 않을 때
+     * @throws CustomException GATHERING_DELETED - 모임이 삭제되었을 때
+     */
+    public Gathering validateGatheringExists(Long gatheringId) {
+        Gathering gathering = gatheringRepository.findById(gatheringId)
+                .orElseThrow(() -> new CustomException(ErrorCode.GATHERING_NOT_FOUND));
+
+        if (gathering.isDeleted()) {
+            throw new CustomException(ErrorCode.GATHERING_DELETED);
+        }
+
+        return gathering;
+    }
+
+    /**
+     * Gathering 참여 인원이 가득 찼는지 검증
+     *
+     * @param gathering 검증할 모임
+     * @param currentParticipantCount 현재 참여자 수
+     * @throws CustomException GATHERING_FULL - 참여 인원이 가득 찼을 때
+     */
+    public void validateGatheringNotFull(Gathering gathering, long currentParticipantCount) {
+        if (currentParticipantCount >= gathering.headCount()) {
+            throw new CustomException(ErrorCode.GATHERING_FULL);
+        }
+    }
+}

--- a/src/main/java/com/yogieat/domain/participant/controller/ParticipantController.java
+++ b/src/main/java/com/yogieat/domain/participant/controller/ParticipantController.java
@@ -1,7 +1,11 @@
 package com.yogieat.domain.participant.controller;
 
-import com.yogieat.domain.participant.service.ParticipantService;
+import com.yogieat.domain.participant.controller.request.CreateParticipantRequest;
+import com.yogieat.domain.participant.controller.response.CreateParticipantResponse;
+import com.yogieat.domain.participant.service.ParticipantFacade;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,5 +13,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/participants")
 @RequiredArgsConstructor
 public class ParticipantController {
-    private final ParticipantService participantService;
+    private final ParticipantFacade participantFacade;
+
+    // 참여 API
+    @PostMapping
+    public CreateParticipantResponse participateInGathering(
+            @RequestBody CreateParticipantRequest request
+    ) {
+        return CreateParticipantResponse.from(
+                participantFacade.participate(request.toCommand())
+        );
+    }
 }

--- a/src/main/java/com/yogieat/domain/participant/controller/request/CreateParticipantRequest.java
+++ b/src/main/java/com/yogieat/domain/participant/controller/request/CreateParticipantRequest.java
@@ -1,0 +1,34 @@
+package com.yogieat.domain.participant.controller.request;
+
+import com.yogieat.domain.participant.domain.command.ParticipantCommand;
+import java.util.List;
+
+public record CreateParticipantRequest(
+        Long gatheringId,
+        Double distance,
+        List<String> dislikes,
+        List<String> preferences
+) {
+    public static CreateParticipantRequest of(
+            Long gatheringId,
+            Double distance,
+            List<String> dislikes,
+            List<String> preferences
+    ) {
+        return new CreateParticipantRequest(
+                gatheringId,
+                distance,
+                dislikes,
+                preferences
+        );
+    }
+
+    public ParticipantCommand.Create toCommand() {
+        return ParticipantCommand.Create.of(
+                gatheringId,
+                distance,
+                dislikes,
+                preferences
+        );
+    }
+}

--- a/src/main/java/com/yogieat/domain/participant/controller/request/CreateParticipantRequest.java
+++ b/src/main/java/com/yogieat/domain/participant/controller/request/CreateParticipantRequest.java
@@ -1,6 +1,8 @@
 package com.yogieat.domain.participant.controller.request;
 
 import com.yogieat.domain.participant.domain.command.ParticipantCommand;
+import com.yogieat.global.error.CustomException;
+import com.yogieat.global.error.ErrorCode;
 import java.util.List;
 
 public record CreateParticipantRequest(
@@ -9,6 +11,23 @@ public record CreateParticipantRequest(
         List<String> dislikes,
         List<String> preferences
 ) {
+    private static final int MAX_DISLIKES_SIZE = 1;
+    private static final int MAX_PREFERENCES_SIZE = 3;
+
+    /**
+     * TODO: 추후 변동사항이 있을 수도 있음
+     * Compact constructor for validation
+     * dislikes: 최대 1개, preferences: 최대 3개까지만 허용
+     */
+    public CreateParticipantRequest {
+        if (dislikes != null && dislikes.size() > MAX_DISLIKES_SIZE) {
+            throw new CustomException(ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
+        }
+        if (preferences != null && preferences.size() > MAX_PREFERENCES_SIZE) {
+            throw new CustomException(ErrorCode.PARTICIPANT_PREFERENCES_EXCEEDED);
+        }
+    }
+
     public static CreateParticipantRequest of(
             Long gatheringId,
             Double distance,

--- a/src/main/java/com/yogieat/domain/participant/controller/response/CreateParticipantResponse.java
+++ b/src/main/java/com/yogieat/domain/participant/controller/response/CreateParticipantResponse.java
@@ -1,0 +1,17 @@
+package com.yogieat.domain.participant.controller.response;
+
+import com.yogieat.domain.participant.domain.result.ParticipantResult;
+
+public record CreateParticipantResponse (
+        Long participantId,
+        Long gatheringId
+) {
+    public static CreateParticipantResponse from(
+            ParticipantResult.Create result
+    ) {
+        return new CreateParticipantResponse(
+                result.participantId(),
+                result.gatheringId()
+        );
+    }
+}

--- a/src/main/java/com/yogieat/domain/participant/domain/Participant.java
+++ b/src/main/java/com/yogieat/domain/participant/domain/Participant.java
@@ -1,11 +1,15 @@
 package com.yogieat.domain.participant.domain;
 
+import com.yogieat.domain.participant.domain.value.DistanceRange;
 import com.yogieat.domain.participant.domain.value.Role;
 
 public record Participant(
         Long id,
         Long userId,
         Long gatheringId,
+        DistanceRange distanceRange,
+        String preferences,
+        String dislikes,
         Role role
 ) {
 }

--- a/src/main/java/com/yogieat/domain/participant/domain/command/ParticipantCommand.java
+++ b/src/main/java/com/yogieat/domain/participant/domain/command/ParticipantCommand.java
@@ -1,0 +1,26 @@
+package com.yogieat.domain.participant.domain.command;
+
+import java.util.List;
+
+public record ParticipantCommand() {
+    public record Create(
+            Long gatheringId,
+            Double distance,
+            List<String> dislikes,
+            List<String> preferences
+    ) {
+        public static Create of(
+                Long gatheringId,
+                Double distance,
+                List<String> dislikes,
+                List<String> preferences
+        ) {
+            return new Create(
+                    gatheringId,
+                    distance,
+                    dislikes,
+                    preferences
+            );
+        }
+    }
+}

--- a/src/main/java/com/yogieat/domain/participant/domain/result/ParticipantResult.java
+++ b/src/main/java/com/yogieat/domain/participant/domain/result/ParticipantResult.java
@@ -1,0 +1,20 @@
+package com.yogieat.domain.participant.domain.result;
+
+import com.yogieat.domain.participant.domain.Participant;
+
+public record ParticipantResult(
+) {
+    public record Create(
+            Long participantId,
+            Long gatheringId
+    ) {
+        public static Create of(
+                Participant participant
+        ) {
+            return new Create(
+                    participant.id(),
+                    participant.gatheringId()
+            );
+        }
+    }
+}

--- a/src/main/java/com/yogieat/domain/participant/domain/value/DistanceRange.java
+++ b/src/main/java/com/yogieat/domain/participant/domain/value/DistanceRange.java
@@ -1,0 +1,39 @@
+package com.yogieat.domain.participant.domain.value;
+
+import lombok.Getter;
+
+@Getter
+public enum DistanceRange {
+    RANGE_500M(0.5),
+    RANGE_1KM(1.0),
+    ANY(null),
+    ;
+
+    private final Double distance;
+
+    DistanceRange(Double distance) {
+        this.distance = distance;
+    }
+
+    /**
+     * Double 값을 DistanceRange로 변환
+     * null이면 ANY 반환
+     */
+    public static DistanceRange fromDistance(Double distance) {
+        if (distance == null) {
+            return ANY;
+        }
+
+        for (DistanceRange range : values()) {
+            if (range == ANY) {
+                continue;
+            }
+            if (range.distance.equals(distance)) {
+                return range;
+            }
+        }
+
+        // 일치하는 값이 없으면 ANY 반환
+        return ANY;
+    }
+}

--- a/src/main/java/com/yogieat/domain/participant/entity/ParticipantEntity.java
+++ b/src/main/java/com/yogieat/domain/participant/entity/ParticipantEntity.java
@@ -1,6 +1,7 @@
 package com.yogieat.domain.participant.entity;
 
 import com.yogieat.domain.participant.domain.Participant;
+import com.yogieat.domain.participant.domain.value.DistanceRange;
 import com.yogieat.domain.participant.domain.value.Role;
 import com.yogieat.global.common.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -25,6 +26,16 @@ public class ParticipantEntity extends BaseEntity {
     @Column(name = "gathering_id")
     private Long gatheringId;
 
+    @Column(name = "distance_range")
+    @Enumerated(EnumType.STRING)
+    private DistanceRange distanceRange;
+
+    @Column(name = "preferences")
+    private String preferences;
+
+    @Column(name = "dislikes")
+    private String dislikes;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role")
     private Role role;
@@ -33,10 +44,27 @@ public class ParticipantEntity extends BaseEntity {
     public ParticipantEntity(
             Long userId,
             Long gatheringId,
+            DistanceRange distanceRange,
+            String preferences,
+            String dislikes,
             Role role) {
         this.userId = userId;
         this.gatheringId = gatheringId;
+        this.distanceRange = distanceRange;
+        this.preferences = preferences;
+        this.dislikes = dislikes;
         this.role = role;
+    }
+
+    public static ParticipantEntity from(Participant participant) {
+        return ParticipantEntity.builder()
+                .userId(participant.userId())
+                .gatheringId(participant.gatheringId())
+                .distanceRange(participant.distanceRange())
+                .preferences(participant.preferences())
+                .dislikes(participant.dislikes())
+                .role(participant.role())
+                .build();
     }
 
     public static Participant toDomain(ParticipantEntity entity) {
@@ -44,6 +72,9 @@ public class ParticipantEntity extends BaseEntity {
                 entity.getId(),
                 entity.getUserId(),
                 entity.getGatheringId(),
+                entity.getDistanceRange(),
+                entity.getPreferences(),
+                entity.getDislikes(),
                 entity.getRole()
         );
     }

--- a/src/main/java/com/yogieat/domain/participant/repository/ParticipantCoreRepository.java
+++ b/src/main/java/com/yogieat/domain/participant/repository/ParticipantCoreRepository.java
@@ -1,5 +1,7 @@
 package com.yogieat.domain.participant.repository;
 
+import com.yogieat.domain.participant.domain.Participant;
+import com.yogieat.domain.participant.entity.ParticipantEntity;
 import com.yogieat.domain.participant.service.ParticipantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -8,4 +10,16 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ParticipantCoreRepository implements ParticipantRepository {
     private final ParticipantJpaRepository participantJpaRepository;
+
+    @Override
+    public Participant save(Participant participant) {
+        ParticipantEntity entity = ParticipantEntity.from(participant);
+        ParticipantEntity savedEntity = participantJpaRepository.save(entity);
+        return ParticipantEntity.toDomain(savedEntity);
+    }
+
+    @Override
+    public long countByGatheringId(Long gatheringId) {
+        return participantJpaRepository.countByGatheringId(gatheringId);
+    }
 }

--- a/src/main/java/com/yogieat/domain/participant/repository/ParticipantJpaRepository.java
+++ b/src/main/java/com/yogieat/domain/participant/repository/ParticipantJpaRepository.java
@@ -4,4 +4,5 @@ import com.yogieat.domain.participant.entity.ParticipantEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantJpaRepository extends JpaRepository<ParticipantEntity, Long> {
+    long countByGatheringId(Long gatheringId);
 }

--- a/src/main/java/com/yogieat/domain/participant/service/ParticipantFacade.java
+++ b/src/main/java/com/yogieat/domain/participant/service/ParticipantFacade.java
@@ -6,43 +6,55 @@ import com.yogieat.domain.participant.domain.Participant;
 import com.yogieat.domain.participant.domain.command.ParticipantCommand;
 import com.yogieat.domain.participant.domain.result.ParticipantResult;
 import com.yogieat.domain.participant.domain.value.DistanceRange;
+import com.yogieat.global.util.LockManager;
 import com.yogieat.global.util.StringUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ParticipantFacade {
     private final ParticipantService participantService;
     private final GatheringService gatheringService;
+    private final LockManager lockManager;
 
     @Transactional
     public ParticipantResult.Create participate(ParticipantCommand.Create command) {
-        // 1. Gathering 존재 여부 및 삭제 여부 검증
-        Gathering gathering = gatheringService.validateGatheringExists(command.gatheringId());
-
-        // 2. 현재 참여자 수 조회
-        long currentParticipantCount = participantService.countByGatheringId(command.gatheringId());
-
-        // 3. Gathering 참여 인원 초과 검증
-        gatheringService.validateGatheringNotFull(gathering, currentParticipantCount);
-
-        // 4. Double distance를 DistanceRange로 변환 (null이면 ANY)
-        DistanceRange distanceRange = DistanceRange.fromDistance(command.distance());
-
-        // 5. List<String>을 콤마로 구분된 String으로 변환
-        String preferences = StringUtils.joinWithComma(command.preferences());
-        String dislikes = StringUtils.joinWithComma(command.dislikes());
-
-        // 6. 참여자 생성 및 저장
-        Participant participant = participantService.create(
+        // Gathering별 락을 사용하여 동시성 제어
+        return lockManager.executeWithLock(
                 command.gatheringId(),
-                distanceRange,
-                preferences,
-                dislikes
-        );
+                () -> {
+                    log.info("Processing participation for gathering: {}", command.gatheringId());
 
-        return ParticipantResult.Create.of(participant);
+                    // 1. Gathering 존재 여부 및 삭제 여부 검증
+                    Gathering gathering =
+                            gatheringService.validateGatheringExists(command.gatheringId());
+
+                    // 2. 현재 참여자 수 조회 (락으로 보호됨)
+                    long currentParticipantCount =
+                            participantService.countByGatheringId(command.gatheringId());
+
+                    // 3. Gathering 참여 인원 초과 검증
+                    gatheringService.validateGatheringNotFull(gathering, currentParticipantCount);
+
+                    // 4. Double distance를 DistanceRange로 변환 (null이면 ANY)
+                    DistanceRange distanceRange = DistanceRange.fromDistance(command.distance());
+
+                    // 5. List<String>을 콤마로 구분된 String으로 변환
+                    String preferences = StringUtils.joinWithComma(command.preferences());
+                    String dislikes = StringUtils.joinWithComma(command.dislikes());
+
+                    // 6. 참여자 생성 및 저장
+                    Participant participant =
+                            participantService.create(
+                                    command.gatheringId(), distanceRange, preferences, dislikes);
+
+                    log.info("Successfully participated in gathering: {}", command.gatheringId());
+
+                    return ParticipantResult.Create.of(participant);
+                });
     }
 }

--- a/src/main/java/com/yogieat/domain/participant/service/ParticipantFacade.java
+++ b/src/main/java/com/yogieat/domain/participant/service/ParticipantFacade.java
@@ -1,0 +1,48 @@
+package com.yogieat.domain.participant.service;
+
+import com.yogieat.domain.gathering.domain.Gathering;
+import com.yogieat.domain.gathering.service.GatheringService;
+import com.yogieat.domain.participant.domain.Participant;
+import com.yogieat.domain.participant.domain.command.ParticipantCommand;
+import com.yogieat.domain.participant.domain.result.ParticipantResult;
+import com.yogieat.domain.participant.domain.value.DistanceRange;
+import com.yogieat.global.util.StringUtils;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantFacade {
+    private final ParticipantService participantService;
+    private final GatheringService gatheringService;
+
+    @Transactional
+    public ParticipantResult.Create participate(ParticipantCommand.Create command) {
+        // 1. Gathering 존재 여부 및 삭제 여부 검증
+        Gathering gathering = gatheringService.validateGatheringExists(command.gatheringId());
+
+        // 2. 현재 참여자 수 조회
+        long currentParticipantCount = participantService.countByGatheringId(command.gatheringId());
+
+        // 3. Gathering 참여 인원 초과 검증
+        gatheringService.validateGatheringNotFull(gathering, currentParticipantCount);
+
+        // 4. Double distance를 DistanceRange로 변환 (null이면 ANY)
+        DistanceRange distanceRange = DistanceRange.fromDistance(command.distance());
+
+        // 5. List<String>을 콤마로 구분된 String으로 변환
+        String preferences = StringUtils.joinWithComma(command.preferences());
+        String dislikes = StringUtils.joinWithComma(command.dislikes());
+
+        // 6. 참여자 생성 및 저장
+        Participant participant = participantService.create(
+                command.gatheringId(),
+                distanceRange,
+                preferences,
+                dislikes
+        );
+
+        return ParticipantResult.Create.of(participant);
+    }
+}

--- a/src/main/java/com/yogieat/domain/participant/service/ParticipantRepository.java
+++ b/src/main/java/com/yogieat/domain/participant/service/ParticipantRepository.java
@@ -1,4 +1,8 @@
 package com.yogieat.domain.participant.service;
 
+import com.yogieat.domain.participant.domain.Participant;
+
 public interface ParticipantRepository {
+    Participant save(Participant participant);
+    long countByGatheringId(Long gatheringId);
 }

--- a/src/main/java/com/yogieat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/yogieat/domain/participant/service/ParticipantService.java
@@ -1,5 +1,8 @@
 package com.yogieat.domain.participant.service;
 
+import com.yogieat.domain.participant.domain.Participant;
+import com.yogieat.domain.participant.domain.value.DistanceRange;
+import com.yogieat.domain.participant.domain.value.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,4 +10,34 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ParticipantService {
     private final ParticipantRepository participantRepository;
+
+    public Participant create(
+            Long gatheringId,
+            DistanceRange distanceRange,
+            String preferences,
+            String dislikes
+    ) {
+        Participant participant = new Participant(
+                null, // id는 저장 시 자동 생성
+                null, // 추후 인증 추가 시 userId로 설정
+                gatheringId,
+                distanceRange,
+                preferences,
+                dislikes,
+                Role.MEMBER // 참여자는 기본적으로 MEMBER 역할
+        );
+        return participantRepository.save(participant);
+    }
+
+
+
+    /**
+     * 특정 모임의 현재 참여자 수 조회
+     *
+     * @param gatheringId 모임 ID
+     * @return 참여자 수
+     */
+    public long countByGatheringId(Long gatheringId) {
+        return participantRepository.countByGatheringId(gatheringId);
+    }
 }

--- a/src/main/java/com/yogieat/global/error/ErrorCode.java
+++ b/src/main/java/com/yogieat/global/error/ErrorCode.java
@@ -30,6 +30,11 @@ public enum ErrorCode {
 	RESTAURANT_COLLECTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R001", "식당 수집 작업 실패"),
 	INVALID_LOCATION_NAME(HttpStatus.BAD_REQUEST, "R002", "알 수 없는 지역명입니다"),
 	INVALID_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "R003", "알 수 없는 카테고리명입니다"),
+
+	// Gathering
+	GATHERING_NOT_FOUND(HttpStatus.NOT_FOUND, "GA001", "해당 모임을 찾을 수 없습니다"),
+	GATHERING_DELETED(HttpStatus.BAD_REQUEST, "GA002", "이미 삭제된 모임입니다"),
+	GATHERING_FULL(HttpStatus.BAD_REQUEST, "GA003", "모임 인원이 가득 찼습니다"),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/yogieat/global/error/ErrorCode.java
+++ b/src/main/java/com/yogieat/global/error/ErrorCode.java
@@ -35,6 +35,10 @@ public enum ErrorCode {
 	GATHERING_NOT_FOUND(HttpStatus.NOT_FOUND, "GA001", "해당 모임을 찾을 수 없습니다"),
 	GATHERING_DELETED(HttpStatus.BAD_REQUEST, "GA002", "이미 삭제된 모임입니다"),
 	GATHERING_FULL(HttpStatus.BAD_REQUEST, "GA003", "모임 인원이 가득 찼습니다"),
+
+	// Participant
+	PARTICIPANT_DISLIKES_EXCEEDED(HttpStatus.BAD_REQUEST, "P001", "비선호 음식은 최대 1개까지 입력 가능합니다"),
+	PARTICIPANT_PREFERENCES_EXCEEDED(HttpStatus.BAD_REQUEST, "P002", "선호 음식은 최대 3개까지 입력 가능합니다"),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/yogieat/global/error/ErrorCode.java
+++ b/src/main/java/com/yogieat/global/error/ErrorCode.java
@@ -39,6 +39,9 @@ public enum ErrorCode {
 	// Participant
 	PARTICIPANT_DISLIKES_EXCEEDED(HttpStatus.BAD_REQUEST, "P001", "비선호 음식은 최대 1개까지 입력 가능합니다"),
 	PARTICIPANT_PREFERENCES_EXCEEDED(HttpStatus.BAD_REQUEST, "P002", "선호 음식은 최대 3개까지 입력 가능합니다"),
+
+	// Lock
+	LOCK_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "L001", "락 획득 시간이 초과되었습니다"),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/yogieat/global/util/LockManager.java
+++ b/src/main/java/com/yogieat/global/util/LockManager.java
@@ -1,27 +1,27 @@
 package com.yogieat.global.util;
 
+import com.yogieat.global.error.CustomException;
+import com.yogieat.global.error.ErrorCode;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
  * 엔티티별 동시성 제어를 위한 범용 Lock Manager
- *
- * <p>ConcurrentHashMap을 사용하여 각 엔티티 ID마다 독립적인 ReentrantLock을 관리합니다.
- *
- * <p>사용 예시:
- *
- * <pre>
+ * ConcurrentHashMap을 사용하여 각 엔티티 ID마다 독립적인 ReentrantLock을 관리합니다.
+ * 사용 예시:
  * lockManager.executeWithLock(entityId, () -> {
  *     // 동시성 제어가 필요한 로직
  *     return result;
  * });
- * </pre>
  */
 @Component
 @Slf4j
 public class LockManager {
+
+    private static final long LOCK_TIMEOUT_SECONDS = 5L;
 
     private final ConcurrentHashMap<Long, ReentrantLock> locks = new ConcurrentHashMap<>();
 
@@ -41,25 +41,38 @@ public class LockManager {
     }
 
     /**
-     * 락을 사용하여 작업 실행 (자동 락 획득/해제)
+     * 락을 사용하여 작업 실행 (자동 락 획득/해제, 타임아웃 적용)
      *
      * @param entityId 엔티티 ID
      * @param task 실행할 작업
      * @param <T> 반환 타입
      * @return 작업 실행 결과
+     * @throws CustomException 락 획득 타임아웃 시
      */
     public <T> T executeWithLock(Long entityId, Task<T> task) {
         ReentrantLock lock = getLock(entityId);
 
-        log.debug("Attempting to acquire lock for entity: {}", entityId);
-        lock.lock(); // 락 획득 (대기)
+        log.debug("Attempting to acquire lock for entity: {} with timeout: {}s", entityId, LOCK_TIMEOUT_SECONDS);
 
+        boolean acquired = false;
         try {
+            acquired = lock.tryLock(LOCK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!acquired) {
+                log.warn("Failed to acquire lock for entity: {} within {}s", entityId, LOCK_TIMEOUT_SECONDS);
+                throw new CustomException(ErrorCode.LOCK_TIMEOUT);
+            }
+
             log.debug("Lock acquired for entity: {}", entityId);
             return task.execute();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Lock acquisition interrupted for entity: {}", entityId);
+            throw new CustomException(ErrorCode.LOCK_TIMEOUT);
         } finally {
-            lock.unlock();
-            log.debug("Lock released for entity: {}", entityId);
+            if (acquired) {
+                lock.unlock();
+                log.debug("Lock released for entity: {}", entityId);
+            }
         }
     }
 
@@ -71,7 +84,6 @@ public class LockManager {
 
     /**
      * 메모리 누수 방지: 삭제된 엔티티의 락 정리 (선택적) 스케줄러로 주기적으로 호출하거나, 엔티티 삭제 시 호출
-     *
      * @param entityId 삭제된 엔티티 ID
      */
     public void removeLock(Long entityId) {
@@ -81,7 +93,6 @@ public class LockManager {
 
     /**
      * 현재 관리 중인 락 개수 (모니터링용)
-     *
      * @return 현재 관리 중인 락의 개수
      */
     public int getLockCount() {

--- a/src/main/java/com/yogieat/global/util/LockManager.java
+++ b/src/main/java/com/yogieat/global/util/LockManager.java
@@ -1,0 +1,90 @@
+package com.yogieat.global.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 엔티티별 동시성 제어를 위한 범용 Lock Manager
+ *
+ * <p>ConcurrentHashMap을 사용하여 각 엔티티 ID마다 독립적인 ReentrantLock을 관리합니다.
+ *
+ * <p>사용 예시:
+ *
+ * <pre>
+ * lockManager.executeWithLock(entityId, () -> {
+ *     // 동시성 제어가 필요한 로직
+ *     return result;
+ * });
+ * </pre>
+ */
+@Component
+@Slf4j
+public class LockManager {
+
+    private final ConcurrentHashMap<Long, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    /**
+     * 특정 엔티티에 대한 락 획득
+     *
+     * @param entityId 엔티티 ID
+     * @return 해당 엔티티의 ReentrantLock (없으면 생성)
+     */
+    public ReentrantLock getLock(Long entityId) {
+        return locks.computeIfAbsent(
+                entityId,
+                id -> {
+                    log.debug("Creating new lock for entity: {}", id);
+                    return new ReentrantLock(true); // fair=true (FIFO 순서 보장)
+                });
+    }
+
+    /**
+     * 락을 사용하여 작업 실행 (자동 락 획득/해제)
+     *
+     * @param entityId 엔티티 ID
+     * @param task 실행할 작업
+     * @param <T> 반환 타입
+     * @return 작업 실행 결과
+     */
+    public <T> T executeWithLock(Long entityId, Task<T> task) {
+        ReentrantLock lock = getLock(entityId);
+
+        log.debug("Attempting to acquire lock for entity: {}", entityId);
+        lock.lock(); // 락 획득 (대기)
+
+        try {
+            log.debug("Lock acquired for entity: {}", entityId);
+            return task.execute();
+        } finally {
+            lock.unlock();
+            log.debug("Lock released for entity: {}", entityId);
+        }
+    }
+
+    /** 작업 실행 인터페이스 (함수형 인터페이스) */
+    @FunctionalInterface
+    public interface Task<T> {
+        T execute();
+    }
+
+    /**
+     * 메모리 누수 방지: 삭제된 엔티티의 락 정리 (선택적) 스케줄러로 주기적으로 호출하거나, 엔티티 삭제 시 호출
+     *
+     * @param entityId 삭제된 엔티티 ID
+     */
+    public void removeLock(Long entityId) {
+        locks.remove(entityId);
+        log.debug("Removed lock for entity: {}", entityId);
+    }
+
+    /**
+     * 현재 관리 중인 락 개수 (모니터링용)
+     *
+     * @return 현재 관리 중인 락의 개수
+     */
+    public int getLockCount() {
+        return locks.size();
+    }
+}

--- a/src/main/java/com/yogieat/global/util/StringUtils.java
+++ b/src/main/java/com/yogieat/global/util/StringUtils.java
@@ -1,0 +1,60 @@
+package com.yogieat.global.util;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 문자열 관련 유틸리티 클래스
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class StringUtils {
+
+    private static final String DELIMITER = ",";
+
+    /**
+     * List<String>을 콤마로 구분된 String으로 변환
+     *
+     * @param list 변환할 문자열 리스트
+     * @return 콤마로 구분된 문자열, 리스트가 null이거나 비어있으면 null 반환
+     */
+    public static String joinWithComma(List<String> list) {
+        if (list == null || list.isEmpty()) {
+            return null;
+        }
+        return String.join(DELIMITER, list);
+    }
+
+    /**
+     * 콤마로 구분된 String을 List<String>으로 변환
+     *
+     * @param str 변환할 문자열
+     * @return 문자열 리스트, 입력이 null이거나 비어있으면 빈 리스트 반환
+     */
+    public static List<String> splitByComma(String str) {
+        if (str == null || str.isBlank()) {
+            return List.of();
+        }
+        return List.of(str.split(DELIMITER));
+    }
+
+    /**
+     * 문자열이 null이거나 비어있는지 확인
+     *
+     * @param str 확인할 문자열
+     * @return null이거나 비어있으면 true
+     */
+    public static boolean isEmpty(String str) {
+        return str == null || str.isEmpty();
+    }
+
+    /**
+     * 문자열이 null이거나 공백만 있는지 확인
+     *
+     * @param str 확인할 문자열
+     * @return null이거나 공백만 있으면 true
+     */
+    public static boolean isBlank(String str) {
+        return str == null || str.isBlank();
+    }
+}

--- a/src/test/java/com/yogieat/domain/gathering/fixture/GatheringFixture.java
+++ b/src/test/java/com/yogieat/domain/gathering/fixture/GatheringFixture.java
@@ -1,0 +1,63 @@
+package com.yogieat.domain.gathering.fixture;
+
+import com.yogieat.domain.common.Place;
+import com.yogieat.domain.gathering.domain.value.TimeSlot;
+import com.yogieat.domain.gathering.entity.GatheringEntity;
+import java.lang.reflect.Constructor;
+import java.time.LocalDate;
+
+/** Test fixture for creating GatheringEntity instances */
+public class GatheringFixture {
+
+    /**
+     * GatheringEntity 인스턴스를 생성합니다 (테스트용)
+     *
+     * @param title 모임 제목
+     * @param headCount 모임 인원
+     * @return GatheringEntity 인스턴스
+     */
+    public static GatheringEntity create(String title, int headCount) {
+        return create(
+                "test-access-key",
+                title,
+                LocalDate.now().plusDays(7),
+                TimeSlot.LUNCH,
+                Place.GANGNAM,
+                headCount);
+    }
+
+    /**
+     * GatheringEntity 인스턴스를 생성합니다 (전체 필드 지정)
+     *
+     * @param accessKey 접근 키
+     * @param title 모임 제목
+     * @param scheduledDate 예정일
+     * @param timeSlot 시간대
+     * @param place 장소
+     * @param headCount 모임 인원
+     * @return GatheringEntity 인스턴스
+     */
+    public static GatheringEntity create(
+            String accessKey,
+            String title,
+            LocalDate scheduledDate,
+            TimeSlot timeSlot,
+            Place place,
+            int headCount) {
+        try {
+            // Reflection을 사용하여 private 생성자 접근
+            Constructor<GatheringEntity> constructor =
+                    GatheringEntity.class.getDeclaredConstructor(
+                            String.class,
+                            String.class,
+                            LocalDate.class,
+                            TimeSlot.class,
+                            Place.class,
+                            int.class);
+            constructor.setAccessible(true);
+            return constructor.newInstance(accessKey, title, scheduledDate, timeSlot, place, headCount);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create GatheringEntity for testing", e);
+        }
+    }
+}

--- a/src/test/java/com/yogieat/domain/participant/controller/request/CreateParticipantRequestTest.java
+++ b/src/test/java/com/yogieat/domain/participant/controller/request/CreateParticipantRequestTest.java
@@ -1,0 +1,190 @@
+package com.yogieat.domain.participant.controller.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yogieat.global.error.CustomException;
+import com.yogieat.global.error.ErrorCode;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CreateParticipantRequestTest {
+
+    @Test
+    @DisplayName("정상적인 요청은 생성에 성공한다")
+    void validRequest_shouldCreateSuccessfully() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파");
+        List<String> preferences = List.of("치킨", "피자", "햄버거");
+
+        // When
+        CreateParticipantRequest request =
+                new CreateParticipantRequest(gatheringId, distance, dislikes, preferences);
+
+        // Then
+        assertThat(request).isNotNull();
+        assertThat(request.gatheringId()).isEqualTo(gatheringId);
+        assertThat(request.distance()).isEqualTo(distance);
+        assertThat(request.dislikes()).hasSize(1);
+        assertThat(request.preferences()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("dislikes가 null이면 생성에 성공한다")
+    void dislikesNull_shouldCreateSuccessfully() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = null;
+        List<String> preferences = List.of("치킨");
+
+        // When
+        CreateParticipantRequest request =
+                new CreateParticipantRequest(gatheringId, distance, dislikes, preferences);
+
+        // Then
+        assertThat(request).isNotNull();
+        assertThat(request.dislikes()).isNull();
+    }
+
+    @Test
+    @DisplayName("preferences가 null이면 생성에 성공한다")
+    void preferencesNull_shouldCreateSuccessfully() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파");
+        List<String> preferences = null;
+
+        // When
+        CreateParticipantRequest request =
+                new CreateParticipantRequest(gatheringId, distance, dislikes, preferences);
+
+        // Then
+        assertThat(request).isNotNull();
+        assertThat(request.preferences()).isNull();
+    }
+
+    @Test
+    @DisplayName("dislikes가 빈 리스트이면 생성에 성공한다")
+    void dislikesEmpty_shouldCreateSuccessfully() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of();
+        List<String> preferences = List.of("치킨");
+
+        // When
+        CreateParticipantRequest request =
+                new CreateParticipantRequest(gatheringId, distance, dislikes, preferences);
+
+        // Then
+        assertThat(request).isNotNull();
+        assertThat(request.dislikes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("preferences가 빈 리스트이면 생성에 성공한다")
+    void preferencesEmpty_shouldCreateSuccessfully() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파");
+        List<String> preferences = List.of();
+
+        // When
+        CreateParticipantRequest request =
+                new CreateParticipantRequest(gatheringId, distance, dislikes, preferences);
+
+        // Then
+        assertThat(request).isNotNull();
+        assertThat(request.preferences()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("dislikes가 1개이면 생성에 성공한다")
+    void dislikesOne_shouldCreateSuccessfully() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파");
+        List<String> preferences = List.of("치킨");
+
+        // When
+        CreateParticipantRequest request =
+                new CreateParticipantRequest(gatheringId, distance, dislikes, preferences);
+
+        // Then
+        assertThat(request).isNotNull();
+        assertThat(request.dislikes()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("dislikes가 2개 이상이면 예외가 발생한다")
+    void dislikesExceeded_shouldThrowException() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파", "마늘");
+        List<String> preferences = List.of("치킨");
+
+        // When & Then
+        assertThatThrownBy(
+                        () -> new CreateParticipantRequest(gatheringId, distance, dislikes, preferences))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("preferences가 3개이면 생성에 성공한다")
+    void preferencesThree_shouldCreateSuccessfully() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파");
+        List<String> preferences = List.of("치킨", "피자", "햄버거");
+
+        // When
+        CreateParticipantRequest request =
+                new CreateParticipantRequest(gatheringId, distance, dislikes, preferences);
+
+        // Then
+        assertThat(request).isNotNull();
+        assertThat(request.preferences()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("preferences가 4개 이상이면 예외가 발생한다")
+    void preferencesExceeded_shouldThrowException() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파");
+        List<String> preferences = List.of("치킨", "피자", "햄버거", "파스타");
+
+        // When & Then
+        assertThatThrownBy(
+                        () -> new CreateParticipantRequest(gatheringId, distance, dislikes, preferences))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_PREFERENCES_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("dislikes 2개, preferences 4개 모두 초과하면 dislikes 예외가 먼저 발생한다")
+    void bothExceeded_shouldThrowDislikesExceptionFirst() {
+        // Given
+        Long gatheringId = 1L;
+        Double distance = 500.0;
+        List<String> dislikes = List.of("양파", "마늘");
+        List<String> preferences = List.of("치킨", "피자", "햄버거", "파스타");
+
+        // When & Then
+        assertThatThrownBy(
+                        () -> new CreateParticipantRequest(gatheringId, distance, dislikes, preferences))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
+    }
+}

--- a/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
+++ b/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
@@ -1,0 +1,147 @@
+package com.yogieat.domain.participant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yogieat.domain.gathering.entity.GatheringEntity;
+import com.yogieat.domain.gathering.fixture.GatheringFixture;
+import com.yogieat.domain.gathering.repository.GatheringJpaRepository;
+import com.yogieat.domain.participant.domain.command.ParticipantCommand;
+import com.yogieat.domain.participant.repository.ParticipantJpaRepository;
+import com.yogieat.global.error.CustomException;
+import com.yogieat.global.error.ErrorCode;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ParticipantFacadeConcurrencyTest {
+
+    @Autowired private ParticipantFacade participantFacade;
+
+    @Autowired private GatheringJpaRepository gatheringRepository;
+
+    @Autowired private ParticipantJpaRepository participantRepository;
+
+    @AfterEach
+    void cleanup() {
+        participantRepository.deleteAll();
+        gatheringRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("동시에 10명이 참여 시도 시 headCount(4)를 초과하지 않는다")
+    void concurrentParticipation_shouldNotExceedHeadCount() throws InterruptedException {
+        // Given: headCount=4인 모임 생성
+        GatheringEntity gathering = GatheringFixture.create("Test Gathering", 4);
+        gatheringRepository.save(gathering);
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // When: 10개 스레드가 동시에 참여 시도
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(
+                    () -> {
+                        try {
+                            ParticipantCommand.Create command =
+                                    new ParticipantCommand.Create(
+                                            gathering.getId(), null, List.of(), List.of());
+                            participantFacade.participate(command);
+                            successCount.incrementAndGet();
+                        } catch (CustomException e) {
+                            if (e.getErrorCode() == ErrorCode.GATHERING_FULL) {
+                                failCount.incrementAndGet();
+                            }
+                        } finally {
+                            latch.countDown();
+                        }
+                    });
+        }
+
+        latch.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // Then: 정확히 4명 성공, 6명 실패
+        assertThat(successCount.get()).isEqualTo(4);
+        assertThat(failCount.get()).isEqualTo(6);
+
+        long actualCount = participantRepository.countByGatheringId(gathering.getId());
+        assertThat(actualCount).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("서로 다른 모임은 동시 참여 가능 (락 독립성)")
+    void differentGatherings_canParticipateSimultaneously() throws InterruptedException {
+        // Given: 2개 모임
+        GatheringEntity gathering1 = createGathering("Gathering 1", 4);
+        GatheringEntity gathering2 = createGathering("Gathering 2", 4);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(2);
+
+        List<Long> executionTimes = new CopyOnWriteArrayList<>();
+
+        // When: 동시에 다른 모임 참여
+        new Thread(
+                        () -> {
+                            try {
+                                startLatch.await();
+                                long start = System.currentTimeMillis();
+                                participantFacade.participate(createCommand(gathering1.getId()));
+                                executionTimes.add(System.currentTimeMillis() - start);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            } finally {
+                                endLatch.countDown();
+                            }
+                        })
+                .start();
+
+        new Thread(
+                        () -> {
+                            try {
+                                startLatch.await();
+                                long start = System.currentTimeMillis();
+                                participantFacade.participate(createCommand(gathering2.getId()));
+                                executionTimes.add(System.currentTimeMillis() - start);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            } finally {
+                                endLatch.countDown();
+                            }
+                        })
+                .start();
+
+        startLatch.countDown(); // 동시 시작
+        endLatch.await(5, TimeUnit.SECONDS);
+
+        // Then: 둘 다 성공, 실행 시간이 거의 동시 (락 대기 없음)
+        assertThat(executionTimes).hasSize(2);
+        assertThat(participantRepository.countByGatheringId(gathering1.getId())).isEqualTo(1);
+        assertThat(participantRepository.countByGatheringId(gathering2.getId())).isEqualTo(1);
+    }
+
+    private GatheringEntity createGathering(String title, int headCount) {
+        GatheringEntity gathering = GatheringFixture.create(title, headCount);
+        return gatheringRepository.save(gathering);
+    }
+
+    private ParticipantCommand.Create createCommand(Long gatheringId) {
+        return new ParticipantCommand.Create(gatheringId, null, List.of(), List.of());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #47 

## 📌 작업 내용

- 5eb7a1f78cca38ccf674cb9ebe562f32e1ceeb83: 모임에 대한 참여 API
- e14489bd7e1b6509f4890b2bcd7acac09f90c135: 모임 동시 참여 시 ReentrantLock으로 동시성 제어
- 7f45357318e24953e790cab49a21605437f53c4f: 선호, 불호에 대한 수 검증

참여 API Request에서 dislikes, preferences는 List<String>으로 받되, 내부적으로 joinString 처리를 하여 저장할 수 있도록 설계했습니다. 선호도에 따른 테이블도 고려를 해보았지만, 결국 관계형에서 참여자 1: 선호도 N에 따른 테이블을 추가 조회를 하는 것이 오히려 row 수가 증가된다면 부하를 일으키지 않을까 고민하였습니다.

추가로 참여 API 호출 시 동시에 발생되는 케이스도 고려하였습니다!
동시 접속을 방지하기 위해 여러 락이 존재하지만, 코드레벨에서 쉽게 도입하기 위해서 일반적인 스레드에 대한 임계 영역 방지를 ReentrantLock을 도입해보았습니다. 
만약 다중 인스턴스 환경이라면 ReentrantLock을 제거하고 Redisson을 사용한 분산 락을 도입해보는 것도 고려를 할 수 있을 거 같아용

의견이 있다면 편하게 알려주세욥 🙇‍♂️

## 📝 참고

ReentrantLock 관련 레퍼런스
- https://velog.io/@eastperson/synchronized%EC%99%80-ReentrantLock-%EA%B7%B8%EB%A6%AC%EA%B3%A0-JDK-21-Virtual-Thread
- https://curiousjinan.tistory.com/entry/java-concurrency-ticket-booking-system-with-reentrant-lock

## 💬 리뷰 요구사항(선택)

-