### PR TITLE
[Feature] 모임 생성 API

### DIFF
--- a/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
@@ -2,9 +2,10 @@ package com.yogieat.domain.gathering.controller;
 
 import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
 import com.yogieat.domain.gathering.controller.response.CreateGatheringResponse;
-import com.yogieat.domain.gathering.service.GatheringService;
+import com.yogieat.domain.gathering.service.GatheringFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,14 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class GatheringController {
 
-    private final GatheringService gatheringService;
+    private final GatheringFacade gatheringFacade;
 
     // 모임 생성 API
     @Operation(summary = "모임 생성", description = "사용자가 모임을 생성합니다.")
     @PostMapping
     public CreateGatheringResponse createGathering(
-            @RequestBody CreateGatheringRequest request
+            @RequestBody @Valid CreateGatheringRequest request
     ) {
-        return gatheringService.createGathering(request);
+        return gatheringFacade.createGathering(request);
     }
 }

--- a/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
@@ -1,11 +1,30 @@
 package com.yogieat.domain.gathering.controller;
 
+import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
+import com.yogieat.domain.gathering.controller.response.CreateGatheringResponse;
+import com.yogieat.domain.gathering.service.GatheringService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "🙋 Gathering API", description = "모임 관련 API")
 @RestController
 @RequestMapping("/api/v1/gatherings")
 @RequiredArgsConstructor
 public class GatheringController {
+
+    private final GatheringService gatheringService;
+
+    // 모임 생성 API
+    @Operation(summary = "모임 생성", description = "사용자가 모임을 생성합니다.")
+    @PostMapping
+    public CreateGatheringResponse createGathering(
+            @RequestBody CreateGatheringRequest request
+    ) {
+        return gatheringService.createGathering(request);
+    }
 }

--- a/src/main/java/com/yogieat/domain/gathering/controller/request/CreateGatheringRequest.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/request/CreateGatheringRequest.java
@@ -1,0 +1,31 @@
+package com.yogieat.domain.gathering.controller.request;
+
+import com.yogieat.domain.common.Region;
+import com.yogieat.domain.gathering.domain.value.TimeSlot;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Schema(description = "모임 생성 요청 정보")
+public record CreateGatheringRequest(
+        @Schema(description = "모임 인원수", example = "4")
+        @NotNull
+        @Min(value = 1)
+        @Max(value = 10)
+        Integer peopleCount,
+
+        @Schema(description = "모임 날짜", example = "2026-01-27")
+        @NotNull
+        LocalDate scheduledDate,
+
+        @Schema(description = "모임 시간대", example = "LUNCH")
+        @NotNull
+        TimeSlot timeSlot,
+
+        @Schema(description = "모임 장소", example = "GANGNAM")
+        @NotNull
+        Region region
+) {
+}

--- a/src/main/java/com/yogieat/domain/gathering/controller/response/CreateGatheringResponse.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/response/CreateGatheringResponse.java
@@ -1,0 +1,10 @@
+package com.yogieat.domain.gathering.controller.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "모임 생성 응답 정보")
+public record CreateGatheringResponse(
+        @Schema(description = "모임 접근키", example = "c2c605069b91")
+        String accessKey
+) {
+}

--- a/src/main/java/com/yogieat/domain/gathering/entity/GatheringEntity.java
+++ b/src/main/java/com/yogieat/domain/gathering/entity/GatheringEntity.java
@@ -57,6 +57,17 @@ public class GatheringEntity extends BaseEntity {
         this.peopleCount = peopleCount;
     }
 
+    public static GatheringEntity from(Gathering gathering) {
+        return GatheringEntity.builder()
+                .accessKey(gathering.accessKey())
+                .title(gathering.title())
+                .scheduledDate(gathering.scheduledDate())
+                .timeSlot(gathering.timeSlot())
+                .region(gathering.region())
+                .peopleCount(gathering.peopleCount())
+                .build();
+    }
+
     public static Gathering toDomain(GatheringEntity entity) {
         return new Gathering(
                 entity.getId(),

--- a/src/main/java/com/yogieat/domain/gathering/repository/GatheringCoreRepository.java
+++ b/src/main/java/com/yogieat/domain/gathering/repository/GatheringCoreRepository.java
@@ -23,4 +23,11 @@ public class GatheringCoreRepository implements GatheringRepository {
         return gatheringJpaRepository.findByAccessKey(accessKey)
                 .map(GatheringEntity::toDomain);
     }
+
+    @Override
+    public Gathering save(Gathering gathering) {
+        GatheringEntity entity = GatheringEntity.from(gathering);
+        GatheringEntity savedEntity = gatheringJpaRepository.save(entity);
+        return GatheringEntity.toDomain(savedEntity);
+    }
 }

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringFacade.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringFacade.java
@@ -1,0 +1,26 @@
+package com.yogieat.domain.gathering.service;
+
+import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
+import com.yogieat.domain.gathering.controller.response.CreateGatheringResponse;
+import com.yogieat.domain.gathering.domain.Gathering;
+import com.yogieat.domain.participant.service.ParticipantService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GatheringFacade {
+
+    private final GatheringService gatheringService;
+    private final ParticipantService participantService;
+
+    @Transactional
+    public CreateGatheringResponse createGathering(CreateGatheringRequest request) {
+        Gathering gathering = gatheringService.create(request);
+        Long gatheringId = gathering.id();
+        participantService.createHostParticipant(request, gatheringId);
+
+        return new CreateGatheringResponse(gathering.accessKey());
+    }
+}

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringFacade.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringFacade.java
@@ -3,7 +3,6 @@ package com.yogieat.domain.gathering.service;
 import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
 import com.yogieat.domain.gathering.controller.response.CreateGatheringResponse;
 import com.yogieat.domain.gathering.domain.Gathering;
-import com.yogieat.domain.participant.service.ParticipantService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,14 +12,10 @@ import org.springframework.stereotype.Service;
 public class GatheringFacade {
 
     private final GatheringService gatheringService;
-    private final ParticipantService participantService;
 
     @Transactional
     public CreateGatheringResponse createGathering(CreateGatheringRequest request) {
         Gathering gathering = gatheringService.create(request);
-        Long gatheringId = gathering.id();
-        participantService.createHostParticipant(request, gatheringId);
-
         return new CreateGatheringResponse(gathering.accessKey());
     }
 }

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringRepository.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 public interface GatheringRepository {
     Optional<Gathering> findById(Long id);
     Optional<Gathering> findByAccessKey(String accessKey);
+    Gathering save(Gathering gathering);
 }

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
@@ -1,9 +1,7 @@
 package com.yogieat.domain.gathering.service;
 
 import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
-import com.yogieat.domain.gathering.controller.response.CreateGatheringResponse;
 import com.yogieat.domain.gathering.domain.Gathering;
-import jakarta.transaction.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -47,14 +45,18 @@ public class GatheringService {
         gatheringValidator.validateGatheringNotFull(gathering, currentParticipantCount);
     }
 
-    @Transactional
-    public CreateGatheringResponse createGathering(CreateGatheringRequest request) {
+    /**
+     * Gathering 생성
+     *
+     * @param request 모임 생성 요청
+     * @return 생성된 Gathering
+     */
+    public Gathering create(CreateGatheringRequest request) {
         gatheringValidator.validateCreate(request);
 
-        String accessKey = createAccessKey();
         Gathering gathering = new Gathering(
                 null,
-                accessKey,
+                createAccessKey(),
                 null,
                 request.scheduledDate(),
                 request.timeSlot(),
@@ -63,14 +65,13 @@ public class GatheringService {
                 null
         );
 
-        gatheringRepository.save(gathering);
-        return new CreateGatheringResponse(accessKey);
+        return gatheringRepository.save(gathering);
     }
 
     private String createAccessKey() {
         return UUID.randomUUID()
-                .toString().
-                replace("-", "")
+                .toString()
+                .replace("-", "")
                 .substring(0, 12);
     }
 

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
@@ -1,6 +1,10 @@
 package com.yogieat.domain.gathering.service;
 
+import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
+import com.yogieat.domain.gathering.controller.response.CreateGatheringResponse;
 import com.yogieat.domain.gathering.domain.Gathering;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,6 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GatheringService {
     private final GatheringValidator gatheringValidator;
+    private final GatheringRepository gatheringRepository;
 
     /**
      * Gathering 존재 여부 및 삭제 여부 검증
@@ -41,4 +46,32 @@ public class GatheringService {
     public void validateGatheringNotFull(Gathering gathering, long currentParticipantCount) {
         gatheringValidator.validateGatheringNotFull(gathering, currentParticipantCount);
     }
+
+    @Transactional
+    public CreateGatheringResponse createGathering(CreateGatheringRequest request) {
+        gatheringValidator.validateCreate(request);
+
+        String accessKey = createAccessKey();
+        Gathering gathering = new Gathering(
+                null,
+                accessKey,
+                null,
+                request.scheduledDate(),
+                request.timeSlot(),
+                request.region(),
+                request.peopleCount(),
+                null
+        );
+
+        gatheringRepository.save(gathering);
+        return new CreateGatheringResponse(accessKey);
+    }
+
+    private String createAccessKey() {
+        return UUID.randomUUID()
+                .toString().
+                replace("-", "")
+                .substring(0, 12);
+    }
+
 }

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringValidator.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringValidator.java
@@ -1,8 +1,10 @@
 package com.yogieat.domain.gathering.service;
 
+import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
 import com.yogieat.domain.gathering.domain.Gathering;
 import com.yogieat.global.error.CustomException;
 import com.yogieat.global.error.ErrorCode;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -62,6 +64,54 @@ public class GatheringValidator {
     public void validateGatheringNotFull(Gathering gathering, long currentParticipantCount) {
         if (currentParticipantCount >= gathering.peopleCount()) {
             throw new CustomException(ErrorCode.GATHERING_FULL);
+        }
+    }
+
+    /**
+     * Gathering 생성 요청에 대한 사전 검증
+     *
+     * @param request 모임 생성 요청 DTO
+     * @throws CustomException GATHERING_PEOPLE_COUNT_REQUIRED - 모임 인원 수가 null일 때
+     * @throws CustomException GATHERING_PEOPLE_COUNT_OUT_OF_RANGE - 모임 인원 수가 허용 범위를 벗어났을 때
+     * @throws CustomException GATHERING_SCHEDULED_DATE_REQUIRED - 모임 날짜가 null일 때
+     * @throws CustomException GATHERING_SCHEDULED_DATE_PAST - 모임 날짜가 과거일 때
+     */
+    public void validateCreate(CreateGatheringRequest request) {
+        validatePeopleCount(request.peopleCount());
+        validateScheduledDate(request.scheduledDate());
+    }
+
+    /**
+     * 모임 인원 수 검증
+     *
+     * @param peopleCount 모임 인원 수
+     * @throws CustomException GATHERING_PEOPLE_COUNT_REQUIRED - 모임 인원 수가 null일 때
+     * @throws CustomException GATHERING_PEOPLE_COUNT_OUT_OF_RANGE - 모임 인원 수가 허용 범위를 벗어났을 때
+     */
+    private void validatePeopleCount(Integer peopleCount) {
+        if (peopleCount == null) {
+            throw new CustomException(ErrorCode.GATHERING_PEOPLE_COUNT_REQUIRED);
+        }
+
+        if (peopleCount < 1 || peopleCount > 10) {
+            throw new CustomException(ErrorCode.GATHERING_PEOPLE_COUNT_OUT_OF_RANGE);
+        }
+    }
+
+    /**
+     * 모임 날짜 검증
+     *
+     * @param scheduledDate 모임 예정 날짜
+     * @throws CustomException GATHERING_SCHEDULED_DATE_REQUIRED - 모임 날짜가 null일 때
+     * @throws CustomException GATHERING_SCHEDULED_DATE_PAST - 모임 날짜가 과거일 때
+     */
+    private void validateScheduledDate(LocalDate scheduledDate) {
+        if (scheduledDate == null) {
+            throw new CustomException(ErrorCode.GATHERING_SCHEDULED_DATE_REQUIRED);
+        }
+
+        if (scheduledDate.isBefore(LocalDate.now())) {
+            throw new CustomException(ErrorCode.GATHERING_SCHEDULED_DATE_PAST);
         }
     }
 }

--- a/src/main/java/com/yogieat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/yogieat/domain/participant/service/ParticipantService.java
@@ -1,8 +1,10 @@
 package com.yogieat.domain.participant.service;
 
+import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
 import com.yogieat.domain.participant.domain.Participant;
 import com.yogieat.domain.participant.domain.value.DistanceRange;
 import com.yogieat.domain.participant.domain.value.Role;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +31,27 @@ public class ParticipantService {
         return participantRepository.save(participant);
     }
 
+    /**
+     * 모임 생성자를 참여자로 등록
+     * - 설문 전 단계이므로 설문 관련 필드는 null 허용
+     *
+     * @param request 모임 생성 요청
+     * @param gatheringId 생성된 모임의 ID
+     */
+    @Transactional
+    public void createHostParticipant(CreateGatheringRequest request, Long gatheringId) {
+        Participant participant = new Participant(
+                null, // id는 저장 시 자동 생성
+                null, // 추후 인증 추가 시 userId로 설정
+                gatheringId,
+                null, // 설문 전
+                null, // 설문 전
+                null, // 설문 전
+                Role.MEMBER // 임시로 MEMBER로 저장
+        );
 
+        participantRepository.save(participant);
+    }
 
     /**
      * 특정 모임의 현재 참여자 수 조회

--- a/src/main/java/com/yogieat/domain/participant/service/ParticipantService.java
+++ b/src/main/java/com/yogieat/domain/participant/service/ParticipantService.java
@@ -1,10 +1,8 @@
 package com.yogieat.domain.participant.service;
 
-import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
 import com.yogieat.domain.participant.domain.Participant;
 import com.yogieat.domain.participant.domain.value.DistanceRange;
 import com.yogieat.domain.participant.domain.value.Role;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,28 +27,6 @@ public class ParticipantService {
                 Role.MEMBER // 참여자는 기본적으로 MEMBER 역할
         );
         return participantRepository.save(participant);
-    }
-
-    /**
-     * 모임 생성자를 참여자로 등록
-     * - 설문 전 단계이므로 설문 관련 필드는 null 허용
-     *
-     * @param request 모임 생성 요청
-     * @param gatheringId 생성된 모임의 ID
-     */
-    @Transactional
-    public void createHostParticipant(CreateGatheringRequest request, Long gatheringId) {
-        Participant participant = new Participant(
-                null, // id는 저장 시 자동 생성
-                null, // 추후 인증 추가 시 userId로 설정
-                gatheringId,
-                null, // 설문 전
-                null, // 설문 전
-                null, // 설문 전
-                Role.MEMBER // 임시로 MEMBER로 저장
-        );
-
-        participantRepository.save(participant);
     }
 
     /**

--- a/src/main/java/com/yogieat/global/error/ErrorCode.java
+++ b/src/main/java/com/yogieat/global/error/ErrorCode.java
@@ -35,6 +35,10 @@ public enum ErrorCode {
 	GATHERING_NOT_FOUND(HttpStatus.NOT_FOUND, "GA001", "해당 모임을 찾을 수 없습니다"),
 	GATHERING_DELETED(HttpStatus.BAD_REQUEST, "GA002", "이미 삭제된 모임입니다"),
 	GATHERING_FULL(HttpStatus.BAD_REQUEST, "GA003", "모임 인원이 가득 찼습니다"),
+    GATHERING_PEOPLE_COUNT_REQUIRED(HttpStatus.BAD_REQUEST, "GA004", "모임 인원 수는 필수입니다"),
+    GATHERING_PEOPLE_COUNT_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "GA005", "모임 인원 수는 1 이상 10 이하여야 합니다"),
+    GATHERING_SCHEDULED_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "GA006", "모임 날짜는 필수입니다"),
+    GATHERING_SCHEDULED_DATE_PAST(HttpStatus.BAD_REQUEST, "GA007", "과거 날짜로는 모임을 생성할 수 없습니다"),
 
 	// Participant
 	PARTICIPANT_DISLIKES_EXCEEDED(HttpStatus.BAD_REQUEST, "P001", "비선호 음식은 최대 1개까지 입력 가능합니다"),


### PR DESCRIPTION
## 🌱 관련 이슈

- close #52

## 📌 작업 내용

- 모임 생성 API 구현
- 모임 생성 요청에 대한 검증 로직 추가
  - 모임 인원 수 필수 여부 및 범위 검증
  - 모임 날짜 과거 여부 검증
- 모임 생성 및 검증 과정에서 사용할 Gathering 관련 에러 코드 정의
- 모임장을 참여자(`MEMBER`)로 함께 등록하도록 처리 (→ 추후 인증 추가 시 모임장을 `HOST`로 등록)
  - 설문 이전 단계이므로 설문 관련 필드는 null 허용

## 📝 참고

- 모임 접근용 `accessKey`는 URL에 포함되어도 가독성과 사용성을 해치지 않도록 UUID를 기반으로 하되, 하이픈 제거 후 12자리로 축약하여 생성했습니다. 이 부분에 대해서 현재 서비스 규모를 고려했을 때 충돌 가능성은 매우 낮다고 판단했습니다 !
- 모임장을 참여자로 저장하는 시점에 대해 고민이 있었으며, 배포 일정 우선으로 모임 생성 직후 참여자(`MEMBER`)를 먼저 생성하고 설문 완료 시에 참여자에 대한 설문 정보를 갱신하는 방식으로 생각하고 구현했습니다.

## 💬 리뷰 요구사항(선택)

- 윤범님 코드 구조를 참고해서 Service에서는 도메인 로직만 두고, 도메인 간 흐름 조합은 Facade에서 처리하도록 구현해봤습니다. 이런 방향으로 이해하고 적용한 게 맞는지 리뷰 부탁드립니다 🙇🏻‍♀️
- 모임장을 참여자로 저장하는 시점을 “모임 생성 직후”로 두는 설계가 적절한지에 대한 의견을 듣고 싶습니다 ! 