### PR TITLE
[Feature] 모임 참여 현황 조회 API

### DIFF
--- a/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
@@ -49,7 +49,8 @@ public class GatheringController {
     }
 
     // 모임 참여 현황 조회 API
-    @GetMapping("/{accessKey}/participants")
+    @Operation(summary = "모임 참여자 현황 조회", description = "모임의 참여자 현황을 조회합니다.")
+    @GetMapping("/{accessKey}/capacity")
     public GetParticipantCountResponse getParticipantStatus(
             @PathVariable String accessKey
     ) {

--- a/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/GatheringController.java
@@ -3,8 +3,10 @@ package com.yogieat.domain.gathering.controller;
 import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
 import com.yogieat.domain.gathering.controller.response.CreateGatheringResponse;
 import com.yogieat.domain.gathering.controller.response.GetGatheringResponse;
+import com.yogieat.domain.gathering.controller.response.GetParticipantCountResponse;
 import com.yogieat.domain.gathering.service.GatheringFacade;
 import com.yogieat.domain.gathering.service.GatheringService;
+import com.yogieat.domain.participant.service.ParticipantService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -24,6 +26,7 @@ public class GatheringController {
 
     private final GatheringFacade gatheringFacade;
     private final GatheringService gatheringService;
+    private final ParticipantService participantService;
 
     // 모임 생성 API
     @Operation(summary = "모임 생성", description = "사용자가 모임을 생성합니다.")
@@ -43,5 +46,13 @@ public class GatheringController {
         return GetGatheringResponse.from(
                 gatheringService.getGatheringByAccessKey(accessKey)
         );
+    }
+
+    // 모임 참여 현황 조회 API
+    @GetMapping("/{accessKey}/participants")
+    public GetParticipantCountResponse getParticipantStatus(
+            @PathVariable String accessKey
+    ) {
+        return gatheringService.getGatheringParticipantStatus(accessKey);
     }
 }

--- a/src/main/java/com/yogieat/domain/gathering/controller/response/GetParticipantCountResponse.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/response/GetParticipantCountResponse.java
@@ -1,7 +1,11 @@
 package com.yogieat.domain.gathering.controller.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record GetParticipantCountResponse(
+        @Schema(description = "현재 참여자 수", example = "2")
         Long currentCount,
+        @Schema(description = "총 참여자 수", example = "4")
         Integer maxCount
 ) {
 }

--- a/src/main/java/com/yogieat/domain/gathering/controller/response/GetParticipantCountResponse.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/response/GetParticipantCountResponse.java
@@ -1,7 +1,7 @@
 package com.yogieat.domain.gathering.controller.response;
 
 public record GetParticipantCountResponse(
-        Long currentPeopleCount,
-        Integer maxPeopleCount
+        Long currentCount,
+        Integer maxCount
 ) {
 }

--- a/src/main/java/com/yogieat/domain/gathering/controller/response/GetParticipantCountResponse.java
+++ b/src/main/java/com/yogieat/domain/gathering/controller/response/GetParticipantCountResponse.java
@@ -1,0 +1,7 @@
+package com.yogieat.domain.gathering.controller.response;
+
+public record GetParticipantCountResponse(
+        Long currentPeopleCount,
+        Integer maxPeopleCount
+) {
+}

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
@@ -1,7 +1,9 @@
 package com.yogieat.domain.gathering.service;
 
 import com.yogieat.domain.gathering.controller.request.CreateGatheringRequest;
+import com.yogieat.domain.gathering.controller.response.GetParticipantCountResponse;
 import com.yogieat.domain.gathering.domain.Gathering;
+import com.yogieat.domain.participant.service.ParticipantService;
 import com.yogieat.global.error.CustomException;
 import com.yogieat.global.error.ErrorCode;
 import java.util.UUID;
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GatheringService {
     private final GatheringValidator gatheringValidator;
     private final GatheringRepository gatheringRepository;
+    private final ParticipantService participantService;
 
     /**
      * Gathering 참여 인원이 가득 찼는지 검증
@@ -32,6 +35,7 @@ public class GatheringService {
      * @param request 모임 생성 요청
      * @return 생성된 Gathering
      */
+    @Transactional
     public Gathering create(CreateGatheringRequest request) {
         gatheringValidator.validateCreate(request);
 
@@ -55,6 +59,17 @@ public class GatheringService {
                 .orElseThrow(() -> new CustomException(ErrorCode.GATHERING_NOT_FOUND));
         gatheringValidator.validateGatheringNotDeleted(gathering);
         return gathering;
+    }
+
+    @Transactional(readOnly = true)
+    public GetParticipantCountResponse getGatheringParticipantStatus(String accessKey) {
+        Gathering gathering = getGatheringByAccessKey(accessKey);
+
+        long currentPeopleCount = participantService.countByGatheringId(gathering.id());
+        return new GetParticipantCountResponse(
+                currentPeopleCount,
+                gathering.peopleCount()
+        );
     }
 
     private String createAccessKey() {

--- a/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
+++ b/src/main/java/com/yogieat/domain/gathering/service/GatheringService.java
@@ -65,9 +65,9 @@ public class GatheringService {
     public GetParticipantCountResponse getGatheringParticipantStatus(String accessKey) {
         Gathering gathering = getGatheringByAccessKey(accessKey);
 
-        long currentPeopleCount = participantService.countByGatheringId(gathering.id());
+        long currentCount = participantService.countByGatheringId(gathering.id());
         return new GetParticipantCountResponse(
-                currentPeopleCount,
+                currentCount,
                 gathering.peopleCount()
         );
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #67 

## 📌 작업 내용

- 모임 참여 현황 조회 API 구현
  - `accessKey`를 통해 모임을 조회한 후, 현재 참여 인원 수와 최대 인원 수를 응답

## 📝 참고

- 참여 인원 수 계산은 기존 `ParticipantService.countByGatheringId()`를 사용했습니다 !

## 💬 리뷰 요구사항(선택)

-