### PR TITLE
[Feature] 참여자 api 내 nickname 필드 추가 구현

### DIFF
--- a/apps/api/src/main/java/com/yogieat/controller/advice/ErrorHttpStatusMapper.java
+++ b/apps/api/src/main/java/com/yogieat/controller/advice/ErrorHttpStatusMapper.java
@@ -21,6 +21,8 @@ public class ErrorHttpStatusMapper {
                  GATHERING_SCHEDULED_DATE_PAST,
                  PARTICIPANT_DISLIKES_EXCEEDED,
                  PARTICIPANT_PREFERENCES_EXCEEDED,
+                 PARTICIPANT_NICKNAME_REQUIRED,
+                 PARTICIPANT_NICKNAME_TOO_LONG,
                  INVALID_CATEGORY_AGGREGATION,
                  INVALID_PREFERENCE_SCORE -> HttpStatus.BAD_REQUEST;
             case METHOD_NOT_ALLOWED -> HttpStatus.METHOD_NOT_ALLOWED;
@@ -30,6 +32,7 @@ public class ErrorHttpStatusMapper {
                  GATHERING_NOT_FOUND -> HttpStatus.NOT_FOUND;
             case GEMINI_API_ERROR,
                  KAKAO_API_ERROR -> HttpStatus.SERVICE_UNAVAILABLE;
+            case DUPLICATE_NICKNAME -> HttpStatus.CONFLICT;
             case KAKAO_RATE_LIMIT_EXCEEDED -> HttpStatus.TOO_MANY_REQUESTS;
             case LOCK_TIMEOUT -> HttpStatus.REQUEST_TIMEOUT;
             default -> HttpStatus.INTERNAL_SERVER_ERROR;

--- a/apps/api/src/main/java/com/yogieat/controller/advice/ErrorHttpStatusMapper.java
+++ b/apps/api/src/main/java/com/yogieat/controller/advice/ErrorHttpStatusMapper.java
@@ -23,6 +23,7 @@ public class ErrorHttpStatusMapper {
                  PARTICIPANT_PREFERENCES_EXCEEDED,
                  PARTICIPANT_NICKNAME_REQUIRED,
                  PARTICIPANT_NICKNAME_TOO_LONG,
+                 PARTICIPANT_NICKNAME_INVALID,
                  INVALID_CATEGORY_AGGREGATION,
                  INVALID_PREFERENCE_SCORE -> HttpStatus.BAD_REQUEST;
             case METHOD_NOT_ALLOWED -> HttpStatus.METHOD_NOT_ALLOWED;

--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
@@ -35,6 +35,8 @@ public record CreateParticipantRequest(
             throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
         }
 
+        nickname = nickname.strip();
+
         if (nickname.length() > MAX_NICKNAME_LENGTH) {
             throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
         }

--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
@@ -10,6 +10,8 @@ import java.util.List;
 public record CreateParticipantRequest(
         @Schema(description = "모임 accessKey", example = "access-key")
         String accessKey,
+        @Schema(description = "참여자 닉네임 (최대 8자)", example = "철수")
+        String nickname,
         @Schema(description = "허용 거리 (km)", example = "0.5")
         Double distance,
         @Schema(description = "참여자 불호 음식 목록", example = "[\"중식\"]")
@@ -19,13 +21,22 @@ public record CreateParticipantRequest(
 ) {
     private static final int MAX_DISLIKES_SIZE = 4;
     private static final int MAX_PREFERENCES_SIZE = 3;
+    private static final int MAX_NICKNAME_LENGTH = 8;
 
     /**
      * TODO: 추후 변동사항이 있을 수도 있음
      * Compact constructor for validation
-     * dislikes: 최소 1개, 최대 4개, preferences: 최대 3개까지만 허용
+     * nickname: 최대 8자 (공백 포함), dislikes: 최소 1개, 최대 4개, preferences: 최대 3개까지만 허용
      */
     public CreateParticipantRequest {
+        if (nickname == null || nickname.isBlank()) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
+        }
+
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
+        }
+
         if (dislikes == null || dislikes.isEmpty() || dislikes.size() > MAX_DISLIKES_SIZE) {
             throw new CustomException(ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
         }
@@ -37,12 +48,14 @@ public record CreateParticipantRequest(
 
     public static CreateParticipantRequest of(
             String accessKey,
+            String nickname,
             Double distance,
             List<String> dislikes,
             List<String> preferences
     ) {
         return new CreateParticipantRequest(
                 accessKey,
+                nickname,
                 distance,
                 dislikes,
                 preferences
@@ -52,6 +65,7 @@ public record CreateParticipantRequest(
     public ParticipantCommand.Create toCommand() {
         return ParticipantCommand.Create.of(
                 accessKey,
+                nickname,
                 distance,
                 dislikes,
                 preferences

--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
@@ -5,6 +5,7 @@ import com.yogieat.common.error.ErrorCode;
 import com.yogieat.participant.domain.command.ParticipantCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Schema(description = "모임 참여 요청 정보")
 public record CreateParticipantRequest(
@@ -22,6 +23,7 @@ public record CreateParticipantRequest(
     private static final int MAX_DISLIKES_SIZE = 4;
     private static final int MAX_PREFERENCES_SIZE = 3;
     private static final int MAX_NICKNAME_LENGTH = 8;
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ\\s]+$");
 
     /**
      * TODO: 추후 변동사항이 있을 수도 있음
@@ -35,6 +37,10 @@ public record CreateParticipantRequest(
 
         if (nickname.length() > MAX_NICKNAME_LENGTH) {
             throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
+        }
+
+        if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_INVALID);
         }
 
         if (dislikes == null || dislikes.isEmpty() || dislikes.size() > MAX_DISLIKES_SIZE) {

--- a/apps/api/src/test/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequestTest.java
+++ b/apps/api/src/test/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequestTest.java
@@ -16,13 +16,14 @@ class CreateParticipantRequestTest {
     void validRequest_shouldCreateSuccessfully() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파");
         List<String> preferences = List.of("치킨", "피자", "햄버거");
 
         // When
         CreateParticipantRequest request =
-                CreateParticipantRequest.of(accessKey, distance, dislikes, preferences);
+                CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences);
 
         // Then
         assertThat(request).isNotNull();
@@ -37,13 +38,14 @@ class CreateParticipantRequestTest {
     void dislikesNull_shouldThrowException() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = null;
         List<String> preferences = List.of("치킨");
 
         // When & Then
         assertThatThrownBy(
-                        () -> CreateParticipantRequest.of(accessKey, distance, dislikes, preferences))
+                () -> CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
     }
@@ -53,13 +55,14 @@ class CreateParticipantRequestTest {
     void preferencesNull_shouldCreateSuccessfully() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파");
         List<String> preferences = null;
 
         // When
         CreateParticipantRequest request =
-                CreateParticipantRequest.of(accessKey, distance, dislikes, preferences);
+                CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences);
 
         // Then
         assertThat(request).isNotNull();
@@ -71,13 +74,14 @@ class CreateParticipantRequestTest {
     void dislikesEmpty_shouldThrowException() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of();
         List<String> preferences = List.of("치킨");
 
         // When & Then
         assertThatThrownBy(
-                        () -> CreateParticipantRequest.of(accessKey, distance, dislikes, preferences))
+                () -> CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
     }
@@ -87,13 +91,14 @@ class CreateParticipantRequestTest {
     void preferencesEmpty_shouldCreateSuccessfully() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파");
         List<String> preferences = List.of();
 
         // When
         CreateParticipantRequest request =
-                CreateParticipantRequest.of(accessKey, distance, dislikes, preferences);
+                CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences);
 
         // Then
         assertThat(request).isNotNull();
@@ -105,13 +110,14 @@ class CreateParticipantRequestTest {
     void dislikesOne_shouldCreateSuccessfully() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파");
         List<String> preferences = List.of("치킨");
 
         // When
         CreateParticipantRequest request =
-                CreateParticipantRequest.of(accessKey, distance, dislikes, preferences);
+                CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences);
 
         // Then
         assertThat(request).isNotNull();
@@ -123,13 +129,14 @@ class CreateParticipantRequestTest {
     void dislikesTwo_shouldCreateSuccessfully() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파", "마늘");
         List<String> preferences = List.of("치킨");
 
         // When
         CreateParticipantRequest request =
-                CreateParticipantRequest.of(accessKey, distance, dislikes, preferences);
+                CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences);
 
         // Then
         assertThat(request).isNotNull();
@@ -141,13 +148,14 @@ class CreateParticipantRequestTest {
     void dislikesFour_shouldCreateSuccessfully() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파", "마늘", "파", "생강");
         List<String> preferences = List.of("치킨");
 
         // When
         CreateParticipantRequest request =
-                CreateParticipantRequest.of(accessKey, distance, dislikes, preferences);
+                CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences);
 
         // Then
         assertThat(request).isNotNull();
@@ -159,13 +167,14 @@ class CreateParticipantRequestTest {
     void dislikesExceeded_shouldThrowException() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파", "마늘", "파", "생강", "고추");
         List<String> preferences = List.of("치킨");
 
         // When & Then
         assertThatThrownBy(
-                        () -> CreateParticipantRequest.of(accessKey, distance, dislikes, preferences))
+                () -> CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
     }
@@ -175,13 +184,14 @@ class CreateParticipantRequestTest {
     void preferencesThree_shouldCreateSuccessfully() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파");
         List<String> preferences = List.of("치킨", "피자", "햄버거");
 
         // When
         CreateParticipantRequest request =
-                CreateParticipantRequest.of(accessKey, distance, dislikes, preferences);
+                CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences);
 
         // Then
         assertThat(request).isNotNull();
@@ -193,13 +203,14 @@ class CreateParticipantRequestTest {
     void preferencesExceeded_shouldThrowException() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파");
         List<String> preferences = List.of("치킨", "피자", "햄버거", "파스타");
 
         // When & Then
         assertThatThrownBy(
-                        () -> CreateParticipantRequest.of(accessKey, distance, dislikes, preferences))
+                () -> CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_PREFERENCES_EXCEEDED);
     }
@@ -209,13 +220,14 @@ class CreateParticipantRequestTest {
     void bothExceeded_shouldThrowDislikesExceptionFirst() {
         // Given
         String accessKey = "test-access-key";
+        String nickname = "닉네임";
         Double distance = 500.0;
         List<String> dislikes = List.of("양파", "마늘", "파", "생강", "고추");
         List<String> preferences = List.of("치킨", "피자", "햄버거", "파스타");
 
         // When & Then
         assertThatThrownBy(
-                        () -> CreateParticipantRequest.of(accessKey, distance, dislikes, preferences))
+                () -> CreateParticipantRequest.of(accessKey, nickname, distance, dislikes, preferences))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);
     }

--- a/apps/api/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
+++ b/apps/api/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
@@ -65,7 +65,7 @@ class ParticipantFacadeConcurrencyTest {
                         try {
                             ParticipantCommand.Create command =
                                     new ParticipantCommand.Create(
-                                            gathering.accessKey(), null, List.of(), List.of());
+                                            gathering.accessKey(), null, null, List.of(), List.of());
                             participantFacade.participate(command);
                             successCount.incrementAndGet();
                         } catch (CustomException e) {
@@ -103,33 +103,33 @@ class ParticipantFacadeConcurrencyTest {
 
         // When: 동시에 다른 모임 참여
         new Thread(
-                        () -> {
-                            try {
-                                startLatch.await();
-                                long start = System.currentTimeMillis();
-                                participantFacade.participate(createCommand(gathering1.accessKey()));
-                                executionTimes.add(System.currentTimeMillis() - start);
-                            } catch (InterruptedException e) {
-                                Thread.currentThread().interrupt();
-                            } finally {
-                                endLatch.countDown();
-                            }
-                        })
+                () -> {
+                    try {
+                        startLatch.await();
+                        long start = System.currentTimeMillis();
+                        participantFacade.participate(createCommand(gathering1.accessKey()));
+                        executionTimes.add(System.currentTimeMillis() - start);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                })
                 .start();
 
         new Thread(
-                        () -> {
-                            try {
-                                startLatch.await();
-                                long start = System.currentTimeMillis();
-                                participantFacade.participate(createCommand(gathering2.accessKey()));
-                                executionTimes.add(System.currentTimeMillis() - start);
-                            } catch (InterruptedException e) {
-                                Thread.currentThread().interrupt();
-                            } finally {
-                                endLatch.countDown();
-                            }
-                        })
+                () -> {
+                    try {
+                        startLatch.await();
+                        long start = System.currentTimeMillis();
+                        participantFacade.participate(createCommand(gathering2.accessKey()));
+                        executionTimes.add(System.currentTimeMillis() - start);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                })
                 .start();
 
         startLatch.countDown(); // 동시 시작
@@ -159,6 +159,6 @@ class ParticipantFacadeConcurrencyTest {
     }
 
     private ParticipantCommand.Create createCommand(String accessKey) {
-        return new ParticipantCommand.Create(accessKey, null, List.of(), List.of());
+        return new ParticipantCommand.Create(accessKey, null, null, List.of(), List.of());
     }
 }

--- a/apps/domain/src/main/java/com/yogieat/common/error/ErrorCode.java
+++ b/apps/domain/src/main/java/com/yogieat/common/error/ErrorCode.java
@@ -44,6 +44,9 @@ public enum ErrorCode {
 	// Participant
 	PARTICIPANT_DISLIKES_EXCEEDED("P001", "비선호 음식은 최소 1개, 최대 4개까지 입력 가능합니다"),
     PARTICIPANT_PREFERENCES_EXCEEDED("P002", "선호 음식은 최대 3개까지 입력 가능합니다"),
+    PARTICIPANT_NICKNAME_REQUIRED("P003", "닉네임은 필수입니다"),
+    PARTICIPANT_NICKNAME_TOO_LONG("P004", "닉네임은 최대 8자까지 입력 가능합니다"),
+    DUPLICATE_NICKNAME("P005", "이미 입장한 사용자입니다"),
 
 	// Lock
 	LOCK_TIMEOUT("L001", "락 획득 시간이 초과되었습니다"),

--- a/apps/domain/src/main/java/com/yogieat/common/error/ErrorCode.java
+++ b/apps/domain/src/main/java/com/yogieat/common/error/ErrorCode.java
@@ -6,56 +6,57 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-	// Sample
-	SAMPLE_ERROR("SAMPLE", "Sample Error Message"),
+    // Sample
+    SAMPLE_ERROR("SAMPLE", "Sample Error Message"),
 
-	// Common
-	METHOD_ARGUMENT_TYPE_MISMATCH("C001", "요청 한 값 타입이 잘못되어 binding에 실패하였습니다."),
-	METHOD_NOT_ALLOWED("C002", "지원하지 않는 HTTP method 입니다."),
-	INTERNAL_SERVER_ERROR("C003", "서버 오류, 관리자에게 문의하세요"),
+    // Common
+    METHOD_ARGUMENT_TYPE_MISMATCH("C001", "요청 한 값 타입이 잘못되어 binding에 실패하였습니다."),
+    METHOD_NOT_ALLOWED("C002", "지원하지 않는 HTTP method 입니다."),
+    INTERNAL_SERVER_ERROR("C003", "서버 오류, 관리자에게 문의하세요"),
 
-	// User
-	USER_NOT_FOUND("U001", "해당 회원을 찾을 수 없습니다."),
+    // User
+    USER_NOT_FOUND("U001", "해당 회원을 찾을 수 없습니다."),
 
-	// Gemini API
-	GEMINI_API_ERROR("G001", "Gemini API 호출 실패"),
-	GEMINI_RESPONSE_PARSE_ERROR("G002", "Gemini 응답 파싱 실패"),
+    // Gemini API
+    GEMINI_API_ERROR("G001", "Gemini API 호출 실패"),
+    GEMINI_RESPONSE_PARSE_ERROR("G002", "Gemini 응답 파싱 실패"),
 
-	// Kakao API
-	KAKAO_API_ERROR("K001", "Kakao API 호출 실패"),
-	KAKAO_RATE_LIMIT_EXCEEDED("K002", "Kakao API 요청 한도 초과"),
+    // Kakao API
+    KAKAO_API_ERROR("K001", "Kakao API 호출 실패"),
+    KAKAO_RATE_LIMIT_EXCEEDED("K002", "Kakao API 요청 한도 초과"),
 
-	// Restaurant Collection
-	RESTAURANT_COLLECTION_FAILED("R001", "식당 수집 작업 실패"),
-	INVALID_LOCATION_NAME("R002", "알 수 없는 지역명입니다"),
-	INVALID_CATEGORY_NAME("R003", "알 수 없는 카테고리명입니다"),
-	CATEGORY_NOT_FOUND("R005", "해당 카테고리를 찾을 수 없습니다"),
-	RESTAURANT_NOT_FOUND("R004", "해당 맛집을 찾을 수 없습니다"),
+    // Restaurant Collection
+    RESTAURANT_COLLECTION_FAILED("R001", "식당 수집 작업 실패"),
+    INVALID_LOCATION_NAME("R002", "알 수 없는 지역명입니다"),
+    INVALID_CATEGORY_NAME("R003", "알 수 없는 카테고리명입니다"),
+    CATEGORY_NOT_FOUND("R005", "해당 카테고리를 찾을 수 없습니다"),
+    RESTAURANT_NOT_FOUND("R004", "해당 맛집을 찾을 수 없습니다"),
 
-	// Gathering
-	GATHERING_NOT_FOUND("GA001", "해당 모임을 찾을 수 없습니다"),
-	GATHERING_DELETED("GA002", "이미 삭제된 모임입니다"),
-	GATHERING_FULL("GA003", "모임 인원이 가득 찼습니다"),
+    // Gathering
+    GATHERING_NOT_FOUND("GA001", "해당 모임을 찾을 수 없습니다"),
+    GATHERING_DELETED("GA002", "이미 삭제된 모임입니다"),
+    GATHERING_FULL("GA003", "모임 인원이 가득 찼습니다"),
     GATHERING_PEOPLE_COUNT_REQUIRED("GA004", "모임 인원 수는 필수입니다"),
     GATHERING_PEOPLE_COUNT_OUT_OF_RANGE("GA005", "모임 인원 수는 1 이상 10 이하여야 합니다"),
     GATHERING_SCHEDULED_DATE_REQUIRED("GA006", "모임 날짜는 필수입니다"),
     GATHERING_SCHEDULED_DATE_PAST("GA007", "과거 날짜로는 모임을 생성할 수 없습니다"),
 
-	// Participant
-	PARTICIPANT_DISLIKES_EXCEEDED("P001", "비선호 음식은 최소 1개, 최대 4개까지 입력 가능합니다"),
+    // Participant
+    PARTICIPANT_DISLIKES_EXCEEDED("P001", "비선호 음식은 최소 1개, 최대 4개까지 입력 가능합니다"),
     PARTICIPANT_PREFERENCES_EXCEEDED("P002", "선호 음식은 최대 3개까지 입력 가능합니다"),
     PARTICIPANT_NICKNAME_REQUIRED("P003", "닉네임은 필수입니다"),
     PARTICIPANT_NICKNAME_TOO_LONG("P004", "닉네임은 최대 8자까지 입력 가능합니다"),
-    DUPLICATE_NICKNAME("P005", "이미 입장한 사용자입니다"),
+    PARTICIPANT_NICKNAME_INVALID("P005", "닉네임에 숫자 또는 특수문자는 사용할 수 없습니다"),
+    DUPLICATE_NICKNAME("P006", "이미 입장한 사용자입니다"),
 
-	// Lock
-	LOCK_TIMEOUT("L001", "락 획득 시간이 초과되었습니다"),
+    // Lock
+    LOCK_TIMEOUT("L001", "락 획득 시간이 초과되었습니다"),
 
-	// Recommend
-	INVALID_CATEGORY_AGGREGATION("REC001", "카테고리 집계 데이터가 올바르지 않습니다"),
-	INVALID_PREFERENCE_SCORE("REC002", "선호도 점수 상태가 올바르지 않습니다"),
-	;
+    // Recommend
+    INVALID_CATEGORY_AGGREGATION("REC001", "카테고리 집계 데이터가 올바르지 않습니다"),
+    INVALID_PREFERENCE_SCORE("REC002", "선호도 점수 상태가 올바르지 않습니다"),
+    ;
 
-	private final String code;
-	private final String message;
+    private final String code;
+    private final String message;
 }

--- a/apps/domain/src/main/java/com/yogieat/participant/domain/Participant.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/domain/Participant.java
@@ -7,6 +7,7 @@ public record Participant(
         Long id,
         Long userId,
         Long gatheringId,
+        String nickname,
         DistanceRange distanceRange,
         String preferences,
         String dislikes,

--- a/apps/domain/src/main/java/com/yogieat/participant/domain/command/ParticipantCommand.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/domain/command/ParticipantCommand.java
@@ -5,18 +5,21 @@ import java.util.List;
 public record ParticipantCommand() {
     public record Create(
             String accessKey,
+            String nickname,
             Double distance,
             List<String> dislikes,
             List<String> preferences
     ) {
         public static Create of(
                 String accessKey,
+                String nickname,
                 Double distance,
                 List<String> dislikes,
                 List<String> preferences
         ) {
             return new Create(
                     accessKey,
+                    nickname,
                     distance,
                     dislikes,
                     preferences

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
@@ -1,5 +1,7 @@
 package com.yogieat.participant.service;
 
+import com.yogieat.common.error.CustomException;
+import com.yogieat.common.error.ErrorCode;
 import com.yogieat.gathering.domain.Gathering;
 import com.yogieat.gathering.domain.result.GatheringResult;
 import com.yogieat.gathering.service.GatheringEventNotifier;
@@ -48,6 +50,13 @@ public class ParticipantFacade {
                     // 3. Gathering 참여 인원 초과 검증
                     gatheringService.validateGatheringNotFull(gathering, currentParticipantCount);
 
+                    // 3-1. 같은 모임 내 닉네임 중복 검증
+                    if (command.nickname() != null &&
+                            participantService.existsByGatheringIdAndNickname(
+                                    gathering.id(), command.nickname())) {
+                        throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+                    }
+
                     // 4. Double distance를 DistanceRange로 변환 (null이면 ANY)
                     DistanceRange distanceRange = DistanceRange.fromDistance(command.distance());
 
@@ -58,7 +67,7 @@ public class ParticipantFacade {
                     // 6. 참여자 생성 및 저장
                     Participant participant =
                             participantService.create(
-                                    gathering.id(), distanceRange, preferences, dislikes);
+                                    gathering.id(), command.nickname(), distanceRange, preferences, dislikes);
 
                     // 7. 참여자 변경 SSE 알림
                     long newCount = currentParticipantCount + 1;

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantRepository.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantRepository.java
@@ -7,4 +7,5 @@ public interface ParticipantRepository {
     Participant save(Participant participant);
     long countByGatheringId(Long gatheringId);
     List<Participant> findByGatheringId(Long gatheringId);
+    boolean existsByGatheringIdAndNickname(Long gatheringId, String nickname);
 }

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantService.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantService.java
@@ -16,6 +16,7 @@ public class ParticipantService {
     @Transactional
     public Participant create(
             Long gatheringId,
+            String nickname,
             DistanceRange distanceRange,
             String preferences,
             String dislikes
@@ -24,12 +25,18 @@ public class ParticipantService {
                 null, // id는 저장 시 자동 생성
                 null, // 추후 인증 추가 시 userId로 설정
                 gatheringId,
+                nickname,
                 distanceRange,
                 preferences,
                 dislikes,
                 Role.MEMBER // 참여자는 기본적으로 MEMBER 역할
         );
         return participantRepository.save(participant);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByGatheringIdAndNickname(Long gatheringId, String nickname) {
+        return participantRepository.existsByGatheringIdAndNickname(gatheringId, nickname);
     }
 
     /**

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/participant/ParticipantCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/participant/ParticipantCoreRepository.java
@@ -30,4 +30,9 @@ public class ParticipantCoreRepository implements ParticipantRepository {
                 .map(ParticipantEntity::toDomain)
                 .toList();
     }
+
+    @Override
+    public boolean existsByGatheringIdAndNickname(Long gatheringId, String nickname) {
+        return participantJpaRepository.existsByGatheringIdAndNickname(gatheringId, nickname);
+    }
 }

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/participant/ParticipantEntity.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/participant/ParticipantEntity.java
@@ -26,6 +26,9 @@ public class ParticipantEntity extends BaseEntity {
     @Column(name = "gathering_id")
     private Long gatheringId;
 
+    @Column(name = "nickname", length = 8)
+    private String nickname;
+
     @Column(name = "distance_range")
     @Enumerated(EnumType.STRING)
     private DistanceRange distanceRange;
@@ -44,12 +47,14 @@ public class ParticipantEntity extends BaseEntity {
     public ParticipantEntity(
             Long userId,
             Long gatheringId,
+            String nickname,
             DistanceRange distanceRange,
             String preferences,
             String dislikes,
             Role role) {
         this.userId = userId;
         this.gatheringId = gatheringId;
+        this.nickname = nickname;
         this.distanceRange = distanceRange;
         this.preferences = preferences;
         this.dislikes = dislikes;
@@ -60,6 +65,7 @@ public class ParticipantEntity extends BaseEntity {
         return ParticipantEntity.builder()
                 .userId(participant.userId())
                 .gatheringId(participant.gatheringId())
+                .nickname(participant.nickname())
                 .distanceRange(participant.distanceRange())
                 .preferences(participant.preferences())
                 .dislikes(participant.dislikes())
@@ -72,6 +78,7 @@ public class ParticipantEntity extends BaseEntity {
                 entity.getId(),
                 entity.getUserId(),
                 entity.getGatheringId(),
+                entity.getNickname(),
                 entity.getDistanceRange(),
                 entity.getPreferences(),
                 entity.getDislikes(),

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/participant/ParticipantJpaRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/participant/ParticipantJpaRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ParticipantJpaRepository extends JpaRepository<ParticipantEntity, Long> {
     long countByGatheringId(Long gatheringId);
     List<ParticipantEntity> findByGatheringId(Long gatheringId);
+    boolean existsByGatheringIdAndNickname(Long gatheringId, String nickname);
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #92

## 📌 작업 내용

- Participant API(`POST` `/api/v1/participants`)에 `nickname` 필드 추가
- `t_participant` 테이블에 `nickname` 컬럼 추가 (nullable, VARCHAR(8))
- 같은 모임 내 닉네임 중복 시 `409` Conflict 예외 처리 ("이미 입장한 사용자입니다")
- `nickname` null/blank 요청 시 `400` Bad Request 예외 처리 ("닉네임은 필수입니다")
- `nickname` 8자 초과 시 `400` Bad Request 예외 처리 ("닉네임은 최대 8자까지 입력 가능합니다")

## 📝 참고

- DB 컬럼은 NOT NULL 제약 없이 nullable로 유지 (기존 데이터 호환)
- `nickname` 필수값 검증은 요청 DTO 레벨에서 처리
- 에러 코드: `P003`(닉네임 필수), `P004`(닉네임 길이 초과), `P005`(닉네임 중복)

## 💬 리뷰 요구사항(선택)

- 기존 데이터 호환을 위해 DB 컬럼은 nullable로 두고, DTO의 compact constructor에서만 null/blank 검증을 하고 있습니다. 
이 방법이 적절한 방법인지에 대한 의견 부탁드립니다 !