### PR TITLE
[Refactor] 추천 알고리즘 고도화 - Cold Start/Freshness/AI 요약 부스트 적용

### DIFF
--- a/apps/api/src/main/java/com/yogieat/controller/v1/recommend/response/RankingRecommendResultResponse.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/recommend/response/RankingRecommendResultResponse.java
@@ -6,6 +6,7 @@ import com.yogieat.common.Region;
 import com.yogieat.participant.domain.value.DistanceRange;
 import com.yogieat.recommend.domain.result.RecommendResultData;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "추천 결과 랭킹 정보")
 public record RankingRecommendResultResponse(
@@ -50,8 +51,8 @@ public record RankingRecommendResultResponse(
         String priceLevel,
         @Schema(description = "AI 요약 제목", example = "맑고 깊은 국물에 담긴 정성 한 그릇")
         String aiMateSummaryTitle,
-        @Schema(description = "AI 요약 내용 (JSON 배열 문자열)", example = "[\"양지곰탕 추천\", \"단체석\", \"콜키지 부과\"]")
-        String aiMateSummaryContents,
+        @Schema(description = "AI 요약 내용", example = "[\"양지곰탕 추천\", \"단체석\", \"콜키지 부과\"]")
+        List<String> aiMateSummaryContents,
         // 추천 근거 텍스트 (신규)
         @Schema(description = "추천 근거 텍스트", example = "5명 중 3명이 일식을 골라서\n400시간 숙성으로 완성한 겉바속촉 돈카츠\n를 추천해요")
         String reasonText

--- a/apps/domain/src/main/java/com/yogieat/recommend/domain/result/RecommendResultData.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/domain/result/RecommendResultData.java
@@ -77,7 +77,7 @@ public record RecommendResultData() {
             Integer representMenuPrice,
             String priceLevel,
             String aiMateSummaryTitle,
-            String aiMateSummaryContents,
+            List<String> aiMateSummaryContents,
             // 추천 근거 텍스트 (신규)
             String reasonText
     ) {
@@ -103,7 +103,7 @@ public record RecommendResultData() {
                 Integer representMenuPrice,
                 String priceLevel,
                 String aiMateSummaryTitle,
-                String aiMateSummaryContents,
+                List<String> aiMateSummaryContents,
                 // 추천 근거 텍스트
                 String reasonText
         ) {

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationService.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationService.java
@@ -1,7 +1,5 @@
 package com.yogieat.recommend.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yogieat.category.domain.Category;
 import com.yogieat.category.domain.value.LargeCategory;
 import com.yogieat.category.service.CategoryService;
@@ -26,7 +24,6 @@ import com.yogieat.util.StringUtils;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -497,9 +494,11 @@ public class RecommendationService {
 
 
     /**
-     * 후보 중에서 다양성을 고려하여 Top 3 선정 (Post-processing Diversification)
-     * - 점수가 높은 순으로 순회하며, 메뉴 타입이 중복되지 않으면 가산점 부여
-     * - 다양성 부스트를 적용한 최종 점수로 Top 3 선정
+     * 후보 중에서 다양성을 고려하여 Top 3 선정 (MMR-style Greedy Selection)
+     *
+     * <p>각 슬롯마다 남은 전체 후보에 현재 선정 컨텍스트 기반 다양성 부스트를 적용하고,
+     * 그 중 최고 점수를 가진 후보를 선택한다. 이를 통해 낮은 base score를 가진 후보라도
+     * 다양성 부스트를 통해 상위권으로 진입할 수 있다.
      *
      * @param candidates 점수 내림차순 정렬된 후보 목록
      * @return 다양성이 고려된 Top 3
@@ -509,36 +508,40 @@ public class RecommendationService {
             return candidates;
         }
 
+        List<ScoredRestaurant> remaining = new ArrayList<>(candidates);
         List<ScoredRestaurant> result = new ArrayList<>();
         Set<String> selectedMenuTypes = new HashSet<>();
 
-        // Greedy 선택: 점수가 높은 순으로 순회하며, 다양성 부스트 적용
-        for (ScoredRestaurant candidate : candidates) {
-            if (result.size() >= TOP_K_SIZE) {
-                break;
+        while (result.size() < TOP_K_SIZE && !remaining.isEmpty()) {
+            // 매 슬롯마다 현재 선정 컨텍스트 기준으로 모든 후보 재평가
+            int bestIndex = 0;
+            double bestScore = Double.NEGATIVE_INFINITY;
+
+            for (int i = 0; i < remaining.size(); i++) {
+                ScoredRestaurant candidate = remaining.get(i);
+                String menuType = classifyMenuType(candidate.restaurant().representMenu());
+                double diversityBoost = selectedMenuTypes.contains(menuType) ? 0.0 : DIVERSITY_BONUS;
+                double boostedScore = roundToThreeDecimals(candidate.totalScore() + diversityBoost);
+
+                if (boostedScore > bestScore) {
+                    bestScore = boostedScore;
+                    bestIndex = i;
+                }
             }
 
-            String menuType = classifyMenuType(candidate.restaurant().representMenu());
+            ScoredRestaurant selected = remaining.remove(bestIndex);
+            String selectedMenuType = classifyMenuType(selected.restaurant().representMenu());
 
-            // 다양성 부스트 계산 (이미 선택된 타입이 아니면 가산점)
-            double diversityBoost = selectedMenuTypes.contains(menuType) ? 0.0 : DIVERSITY_BONUS;
-            double finalScore = roundToThreeDecimals(candidate.totalScore() + diversityBoost);
-
-            // 결과에 추가 (다양성 부스트가 적용된 새 점수로)
-            ScoredRestaurant boosted = new ScoredRestaurant(
-                    candidate.restaurant(),
-                    finalScore,
-                    candidate.agreementRate(),
-                    candidate.reasonText()
-            );
-
-            result.add(boosted);
-            selectedMenuTypes.add(menuType);
+            result.add(new ScoredRestaurant(
+                    selected.restaurant(),
+                    bestScore,
+                    selected.agreementRate(),
+                    selected.reasonText()
+            ));
+            selectedMenuTypes.add(selectedMenuType);
         }
 
-        // 최종 점수로 재정렬
         result.sort(Comparator.comparingDouble(ScoredRestaurant::totalScore).reversed());
-
         return result;
     }
 
@@ -632,12 +635,14 @@ public class RecommendationService {
      * @return 신뢰도 점수
      */
     private double calculateCredibilityScore(Double rating, Integer reviewCount, Integer blogReviewCount) {
-        if (rating == null || reviewCount == null || reviewCount == 0) {
+        if (rating == null || ((reviewCount == null || reviewCount == 0) && (blogReviewCount == null || blogReviewCount == 0))) {
             return 0.0;
         }
 
         // 카카오맵 리뷰 수 가중치 (로그 스케일로 급격한 증가 방지)
-        double kakaoWeight = Math.log10(reviewCount + 1);
+        double kakaoWeight = (reviewCount != null && reviewCount > 0)
+                ? Math.log10(reviewCount + 1)
+                : 0.0;
 
         // 블로그 리뷰 가중치 (블로그 리뷰는 더 상세하므로 가중치 적용)
         double blogWeight = 0.0;
@@ -715,61 +720,37 @@ public class RecommendationService {
 
     /**
      * AI 요약 기반 부스트 점수 계산
-     * aiMateSummaryContents JSON 배열에서 키워드를 추출하여 그룹 특성과 매칭
+     * aiMateSummaryContents 키워드 리스트로 그룹 특성과 매칭
      *
-     * @param aiMateSummaryContents AI 요약 내용 (JSON 문자열)
+     * @param summaryItems AI 요약 항목 리스트
      * @param participantCount 참여자 수
      * @return 부스트 점수 (-0.2 ~ +0.8)
      */
-    private double calculateAiSummaryBoost(String aiMateSummaryContents, int participantCount) {
-        if (aiMateSummaryContents == null || aiMateSummaryContents.isBlank()) {
+    private double calculateAiSummaryBoost(List<String> summaryItems, int participantCount) {
+        if (summaryItems == null || summaryItems.isEmpty()) {
             return 0.0;
         }
 
-        try {
-            List<String> summaryItems = parseJsonArray(aiMateSummaryContents);
-            if (summaryItems.isEmpty()) {
-                return 0.0;
+        double boost = 0.0;
+
+        // 그룹 친화 키워드 매칭 (GROUP_SIZE_THRESHOLD명 이상일 때)
+        if (participantCount >= GROUP_SIZE_THRESHOLD) {
+            if (containsAnyKeyword(summaryItems, "단체석", "대형 테이블", "모임", "단체")) {
+                boost += AI_GROUP_BOOST;
             }
-
-            double boost = 0.0;
-
-            // 그룹 친화 키워드 매칭 (GROUP_SIZE_THRESHOLD명 이상일 때)
-            if (participantCount >= GROUP_SIZE_THRESHOLD) {
-                if (containsAnyKeyword(summaryItems, "단체석", "대형 테이블", "모임", "단체")) {
-                    boost += AI_GROUP_BOOST;
-                }
-            }
-
-            // 긍정 키워드 가산
-            if (containsAnyKeyword(summaryItems, "추천", "인기", "맛집", "특별", "유명")) {
-                boost += AI_POSITIVE_BOOST;
-            }
-
-            // 부정 키워드 감점 (웨이팅이 있으면 모임에 불편)
-            if (containsAnyKeyword(summaryItems, "웨이팅 필수", "예약 필수", "대기 시간")) {
-                boost += AI_NEGATIVE_PENALTY;
-            }
-
-            return boost;
-        } catch (Exception e) {
-            log.warn("Failed to parse aiMateSummaryContents: {}", aiMateSummaryContents);
-            return 0.0;
-        }
-    }
-
-    private List<String> parseJsonArray(String jsonArrayStr) {
-        if (jsonArrayStr == null || jsonArrayStr.isBlank()) {
-            return Collections.emptyList();
         }
 
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.readValue(jsonArrayStr, new TypeReference<List<String>>() {});
-        } catch (Exception e) {
-            log.warn("Failed to parse JSON array: {}", jsonArrayStr);
-            return Collections.emptyList();
+        // 긍정 키워드 가산
+        if (containsAnyKeyword(summaryItems, "추천", "인기", "맛집", "특별", "유명")) {
+            boost += AI_POSITIVE_BOOST;
         }
+
+        // 부정 키워드 감점 (웨이팅이 있으면 모임에 불편)
+        if (containsAnyKeyword(summaryItems, "웨이팅 필수", "예약 필수", "대기 시간")) {
+            boost += AI_NEGATIVE_PENALTY;
+        }
+
+        return boost;
     }
 
     /**

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationService.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationService.java
@@ -1,5 +1,7 @@
 package com.yogieat.recommend.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yogieat.category.domain.Category;
 import com.yogieat.category.domain.value.LargeCategory;
 import com.yogieat.category.service.CategoryService;
@@ -22,7 +24,16 @@ import com.yogieat.restaurant.domain.Restaurant;
 import com.yogieat.restaurant.service.RestaurantRepository;
 import com.yogieat.util.StringUtils;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +44,46 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class RecommendationService {
+
+    // ========== 점수 가중치 상수 ==========
+    private static final double PREFERENCE_RANK_1_SCORE = 3.0;
+    private static final double PREFERENCE_RANK_2_SCORE = 2.0;
+    private static final double PREFERENCE_RANK_3_SCORE = 1.0;
+    private static final double DISLIKE_PENALTY = 2.0;
+
+    private static final double DISTANCE_BONUS = 1.0;
+    private static final double DIVERSITY_BONUS = 0.5;
+    private static final double NEUTRAL_PENALTY = -0.5;
+
+    // AI 요약 부스트 상수
+    private static final double AI_GROUP_BOOST = 0.5;
+    private static final double AI_POSITIVE_BOOST = 0.3;
+    private static final double AI_NEGATIVE_PENALTY = -0.2;
+    private static final int GROUP_SIZE_THRESHOLD = 4;
+
+    // ========== Cold Start / Freshness 상수 ==========
+    private static final int COLD_START_DAYS_THRESHOLD = 30;
+    private static final int COLD_START_REVIEW_THRESHOLD = 10;
+    private static final double COLD_START_RATING_THRESHOLD = 4.0;
+    private static final double COLD_START_BOOST = 0.3;
+
+    private static final int FRESHNESS_RECENT_DAYS = 7;
+    private static final int FRESHNESS_MODERATE_DAYS = 30;
+    private static final int FRESHNESS_STALE_DAYS = 90;
+    private static final double FRESHNESS_RECENT_BOOST = 0.3;
+    private static final double FRESHNESS_MODERATE_BOOST = 0.1;
+    private static final double FRESHNESS_STALE_PENALTY = -0.2;
+
+    // ========== 신뢰도 점수 상수 ==========
+    private static final double BLOG_REVIEW_WEIGHT_MULTIPLIER = 1.5;
+    private static final double MAX_REVIEW_WEIGHT = 5.0;
+    private static final double RATING_MIN = 3.0;
+    private static final double RATING_MAX = 5.0;
+
+    // ========== 후보 선정 상수 ==========
+    private static final int CANDIDATE_POOL_SIZE = 10;
+    private static final int TOP_K_SIZE = 3;
+
     private final ParticipantRepository participantRepository;
     private final RestaurantRepository restaurantRepository;
     private final CategoryService categoryService;
@@ -301,12 +352,10 @@ public class RecommendationService {
         );
 
         if (!results.isEmpty()) {
-            log.info("Found {} restaurants with preference score > 0", results.size());
             return results;
         }
 
         // 2단계: 불호만 필터링
-        log.warn("No restaurants found with preference score > 0. Filtering only disliked categories...");
         results = scoreAndFilterRestaurants(
             restaurants, categoryMap, preferenceScoreMap,
             dislikedCategories,
@@ -315,15 +364,12 @@ public class RecommendationService {
             gatheringTimeSlot
         );
 
-        if (!results.isEmpty()) {
-            log.info("Found {} restaurants by excluding only disliked categories", results.size());
-        }
-
         return results;
     }
 
     /**
      * 레스토랑 점수 계산 및 필터링을 수행하여 Top 3 추출
+     * (개선: Post-processing Diversification 패턴 적용, Cold Start/Freshness 부스트 추가)
      *
      * @param restaurants 전체 레스토랑 목록
      * @param categoryMap 카테고리 정보 Map
@@ -347,11 +393,13 @@ public class RecommendationService {
             FilterStrategy strategy,
             TimeSlot gatheringTimeSlot) {
 
-        PriorityQueue<ScoredRestaurant> top3Heap = new PriorityQueue<>(
+        // 1단계: 다양성 부스트 없이 기본 점수로 상위 후보 선정
+        PriorityQueue<ScoredRestaurant> candidateHeap = new PriorityQueue<>(
             Comparator.comparingDouble(ScoredRestaurant::totalScore)
         );
 
         int totalParticipants = participants.size();
+        LocalDateTime now = LocalDateTime.now();
 
         for (Restaurant restaurant : restaurants) {
             // TimeSlot 필터링 (최우선)
@@ -376,24 +424,27 @@ public class RecommendationService {
                 continue;
             }
 
-            // 점수 계산 (개선된 알고리즘)
-            double totalScore = 0.0;
+            // 기본 점수 계산 (다양성 부스트 제외)
+            double baseScore = 0.0;
 
             // 1. 기존 선호도 점수
-            totalScore += preferenceScore.calculateFinalScore();
+            baseScore += preferenceScore.calculateFinalScore();
 
-            // 2. 순수 선호수 가산점 (신규)
-            totalScore += preferenceScore.calculateNetPreferenceBonus();
+            // 2. 순수 선호수 가산점
+            baseScore += preferenceScore.calculateNetPreferenceBonus();
 
-            // 3. 리뷰/평점 신뢰도 점수 (신규)
-            totalScore += calculateCredibilityScore(restaurant.rating(), restaurant.reviewCount());
+            // 3. 리뷰/평점 신뢰도 점수
+            baseScore += calculateCredibilityScore(
+                    restaurant.rating(),
+                    restaurant.reviewCount(),
+                    restaurant.blogReviewCount()
+            );
 
             // 4. 거리 가산점
             if (majorityRange != DistanceRange.ANY && restaurant.location() != null) {
                 double distance = calculateDistance(centerPoint, restaurant.location());
-                boolean withinRange = isWithinDistanceRange(distance, majorityRange);
-                if (withinRange) {
-                    totalScore += 1.0;
+                if (isWithinDistanceRange(distance, majorityRange)) {
+                    baseScore += DISTANCE_BONUS;
                 }
             }
 
@@ -401,12 +452,24 @@ public class RecommendationService {
             double agreementRate = getAgreementRate(participants, preferenceScore);
 
             // 5. 의견일치율 가산점 (0~100% → 0~1점)
-            totalScore += agreementRate / 100.0;
+            baseScore += agreementRate / 100.0;
 
-            // 6. 소수점 셋째 자리 반올림
-            totalScore = Math.round(totalScore * 1000.0) / 1000.0;
+            // 6. AI 요약 부스트 점수
+            baseScore += calculateAiSummaryBoost(
+                    restaurant.aiMateSummaryContents(),
+                    totalParticipants
+            );
 
-            // 추천 근거 텍스트 생성 (신규)
+            // 7. Cold Start 부스트 (신규 맛집 지원)
+            baseScore += calculateColdStartBoost(restaurant, now);
+
+            // 8. Freshness 부스트 (정보 신선도)
+            baseScore += calculateFreshnessBoost(restaurant, now);
+
+            // 소수점 셋째 자리 반올림
+            baseScore = roundToThreeDecimals(baseScore);
+
+            // 추천 근거 텍스트 생성
             String reasonText = buildReasonText(
                     totalParticipants,
                     preferenceScore.preferenceCount(),
@@ -414,22 +477,69 @@ public class RecommendationService {
                     restaurant.aiMateSummaryTitle()
             );
 
-            ScoredRestaurant scored = new ScoredRestaurant(restaurant, totalScore, agreementRate, reasonText);
+            ScoredRestaurant scored = new ScoredRestaurant(restaurant, baseScore, agreementRate, reasonText);
 
-            // Top-K 알고리즘: 상위 3개만 유지
-            if (top3Heap.size() < 3) {
-                top3Heap.offer(scored);
-            } else if (scored.totalScore() > top3Heap.peek().totalScore()) {
-                top3Heap.poll();
-                top3Heap.offer(scored);
+            // 상위 후보만 유지 (CANDIDATE_POOL_SIZE개)
+            if (candidateHeap.size() < CANDIDATE_POOL_SIZE) {
+                candidateHeap.offer(scored);
+            } else if (scored.totalScore() > candidateHeap.peek().totalScore()) {
+                candidateHeap.poll();
+                candidateHeap.offer(scored);
             }
         }
 
-        // 상위 3개 추출 및 정렬
-        List<ScoredRestaurant> top3 = new ArrayList<>(top3Heap);
-        top3.sort(Comparator.comparingDouble(ScoredRestaurant::totalScore).reversed());
+        // 2단계: 후보 중에서 다양성을 고려하여 최종 Top 3 선정 (Post-processing Diversification)
+        List<ScoredRestaurant> candidates = new ArrayList<>(candidateHeap);
+        candidates.sort(Comparator.comparingDouble(ScoredRestaurant::totalScore).reversed());
 
-        return top3;
+        return selectTop3WithDiversity(candidates);
+    }
+
+
+    /**
+     * 후보 중에서 다양성을 고려하여 Top 3 선정 (Post-processing Diversification)
+     * - 점수가 높은 순으로 순회하며, 메뉴 타입이 중복되지 않으면 가산점 부여
+     * - 다양성 부스트를 적용한 최종 점수로 Top 3 선정
+     *
+     * @param candidates 점수 내림차순 정렬된 후보 목록
+     * @return 다양성이 고려된 Top 3
+     */
+    private List<ScoredRestaurant> selectTop3WithDiversity(List<ScoredRestaurant> candidates) {
+        if (candidates.size() <= TOP_K_SIZE) {
+            return candidates;
+        }
+
+        List<ScoredRestaurant> result = new ArrayList<>();
+        Set<String> selectedMenuTypes = new HashSet<>();
+
+        // Greedy 선택: 점수가 높은 순으로 순회하며, 다양성 부스트 적용
+        for (ScoredRestaurant candidate : candidates) {
+            if (result.size() >= TOP_K_SIZE) {
+                break;
+            }
+
+            String menuType = classifyMenuType(candidate.restaurant().representMenu());
+
+            // 다양성 부스트 계산 (이미 선택된 타입이 아니면 가산점)
+            double diversityBoost = selectedMenuTypes.contains(menuType) ? 0.0 : DIVERSITY_BONUS;
+            double finalScore = roundToThreeDecimals(candidate.totalScore() + diversityBoost);
+
+            // 결과에 추가 (다양성 부스트가 적용된 새 점수로)
+            ScoredRestaurant boosted = new ScoredRestaurant(
+                    candidate.restaurant(),
+                    finalScore,
+                    candidate.agreementRate(),
+                    candidate.reasonText()
+            );
+
+            result.add(boosted);
+            selectedMenuTypes.add(menuType);
+        }
+
+        // 최종 점수로 재정렬
+        result.sort(Comparator.comparingDouble(ScoredRestaurant::totalScore).reversed());
+
+        return result;
     }
 
     private static double getAgreementRate(List<Participant> participants, PreferenceScore preferenceScore) {
@@ -512,28 +622,249 @@ public class RecommendationService {
 
 
     /**
-     * 리뷰/평점 신뢰도 점수 계산
+     * 리뷰/평점 신뢰도 점수 계산 (개선: 블로그 리뷰 반영)
      * Wilson Score 기반 간소화 버전: 4.5점 100개 리뷰 > 5.0점 1개 리뷰
+     * 블로그 리뷰는 일반 리뷰보다 상세하므로 1.5배 가중치 적용
      *
      * @param rating 평점 (1.0~5.0)
-     * @param reviewCount 리뷰 수
+     * @param reviewCount 카카오맵 리뷰 수
+     * @param blogReviewCount 블로그 리뷰 수
      * @return 신뢰도 점수
      */
-    private double calculateCredibilityScore(Double rating, Integer reviewCount) {
+    private double calculateCredibilityScore(Double rating, Integer reviewCount, Integer blogReviewCount) {
         if (rating == null || reviewCount == null || reviewCount == 0) {
             return 0.0;
         }
 
-        // 리뷰 수 가중치 (로그 스케일로 급격한 증가 방지)
-        // 100개 → 2.0, 1000개 → 3.0
-        double reviewWeight = Math.log10(reviewCount + 1);
+        // 카카오맵 리뷰 수 가중치 (로그 스케일로 급격한 증가 방지)
+        double kakaoWeight = Math.log10(reviewCount + 1);
 
-        // 평점 정규화 (3.0~5.0 → 0.0~1.0)
-        double normalizedRating = (rating - 3.0) / 2.0;
+        // 블로그 리뷰 가중치 (블로그 리뷰는 더 상세하므로 가중치 적용)
+        double blogWeight = 0.0;
+        if (blogReviewCount != null && blogReviewCount > 0) {
+            blogWeight = Math.log10(blogReviewCount + 1) * BLOG_REVIEW_WEIGHT_MULTIPLIER;
+        }
+
+        // 총 리뷰 가중치 (최대값으로 제한)
+        double totalReviewWeight = Math.min(kakaoWeight + blogWeight, MAX_REVIEW_WEIGHT);
+
+        // 평점 정규화 (RATING_MIN~RATING_MAX → 0.0~1.0)
+        double normalizedRating = (rating - RATING_MIN) / (RATING_MAX - RATING_MIN);
         normalizedRating = Math.max(0.0, Math.min(1.0, normalizedRating));
 
-        // 신뢰도 점수 = 평점 × 리뷰 가중치
-        return normalizedRating * reviewWeight;
+        // 신뢰도 점수 = 평점 × 총 리뷰 가중치
+        return normalizedRating * totalReviewWeight;
+    }
+
+
+    /**
+     * Cold Start 부스트 점수 계산
+     * 신규 맛집(등록 30일 이내 또는 리뷰 10개 미만)에 가산점 부여
+     * 단, 평점이 4.0 이상인 경우에만 부스트 적용 (잠재력 있는 신규)
+     *
+     * @param restaurant 레스토랑 정보
+     * @param now 현재 시간
+     * @return Cold Start 부스트 점수 (0.0 또는 COLD_START_BOOST)
+     */
+    private double calculateColdStartBoost(Restaurant restaurant, LocalDateTime now) {
+        if (restaurant.createdAt() == null) {
+            return 0.0;
+        }
+
+        boolean isNewRestaurant = ChronoUnit.DAYS.between(
+                restaurant.createdAt(), now) <= COLD_START_DAYS_THRESHOLD;
+        boolean hasLowReviewCount = restaurant.reviewCount() == null
+                || restaurant.reviewCount() < COLD_START_REVIEW_THRESHOLD;
+        boolean hasGoodRating = restaurant.rating() != null
+                && restaurant.rating() >= COLD_START_RATING_THRESHOLD;
+
+        // 신규 맛집이면서 평점이 좋은 경우에만 부스트
+        if ((isNewRestaurant || hasLowReviewCount) && hasGoodRating) {
+            return COLD_START_BOOST;
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * Freshness 부스트 점수 계산
+     * 최근 업데이트된 맛집에 가산점, 오래된 정보에 페널티
+     *
+     * @param restaurant 레스토랑 정보
+     * @param now 현재 시간
+     * @return Freshness 부스트 점수 (-0.2 ~ +0.3)
+     */
+    private double calculateFreshnessBoost(Restaurant restaurant, LocalDateTime now) {
+        if (restaurant.updatedAt() == null) {
+            return 0.0;
+        }
+
+        long daysSinceUpdate = ChronoUnit.DAYS.between(
+                restaurant.updatedAt(), now);
+
+        if (daysSinceUpdate <= FRESHNESS_RECENT_DAYS) {
+            return FRESHNESS_RECENT_BOOST;  // 7일 이내: +0.3
+        } else if (daysSinceUpdate <= FRESHNESS_MODERATE_DAYS) {
+            return FRESHNESS_MODERATE_BOOST;  // 30일 이내: +0.1
+        } else if (daysSinceUpdate >= FRESHNESS_STALE_DAYS) {
+            return FRESHNESS_STALE_PENALTY;  // 90일 이상: -0.2
+        }
+
+        return 0.0;  // 30~90일: 0점
+    }
+
+    /**
+     * AI 요약 기반 부스트 점수 계산
+     * aiMateSummaryContents JSON 배열에서 키워드를 추출하여 그룹 특성과 매칭
+     *
+     * @param aiMateSummaryContents AI 요약 내용 (JSON 문자열)
+     * @param participantCount 참여자 수
+     * @return 부스트 점수 (-0.2 ~ +0.8)
+     */
+    private double calculateAiSummaryBoost(String aiMateSummaryContents, int participantCount) {
+        if (aiMateSummaryContents == null || aiMateSummaryContents.isBlank()) {
+            return 0.0;
+        }
+
+        try {
+            List<String> summaryItems = parseJsonArray(aiMateSummaryContents);
+            if (summaryItems.isEmpty()) {
+                return 0.0;
+            }
+
+            double boost = 0.0;
+
+            // 그룹 친화 키워드 매칭 (GROUP_SIZE_THRESHOLD명 이상일 때)
+            if (participantCount >= GROUP_SIZE_THRESHOLD) {
+                if (containsAnyKeyword(summaryItems, "단체석", "대형 테이블", "모임", "단체")) {
+                    boost += AI_GROUP_BOOST;
+                }
+            }
+
+            // 긍정 키워드 가산
+            if (containsAnyKeyword(summaryItems, "추천", "인기", "맛집", "특별", "유명")) {
+                boost += AI_POSITIVE_BOOST;
+            }
+
+            // 부정 키워드 감점 (웨이팅이 있으면 모임에 불편)
+            if (containsAnyKeyword(summaryItems, "웨이팅 필수", "예약 필수", "대기 시간")) {
+                boost += AI_NEGATIVE_PENALTY;
+            }
+
+            return boost;
+        } catch (Exception e) {
+            log.warn("Failed to parse aiMateSummaryContents: {}", aiMateSummaryContents);
+            return 0.0;
+        }
+    }
+
+    private List<String> parseJsonArray(String jsonArrayStr) {
+        if (jsonArrayStr == null || jsonArrayStr.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(jsonArrayStr, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            log.warn("Failed to parse JSON array: {}", jsonArrayStr);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 문자열 리스트에 특정 키워드들 중 하나라도 포함되어 있는지 확인
+     */
+    private boolean containsAnyKeyword(List<String> items, String... keywords) {
+        for (String item : items) {
+            for (String keyword : keywords) {
+                if (item.contains(keyword)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 메뉴 다양성 부스트 점수 계산
+     * Top 3 추천 시 메뉴 타입이 중복되지 않도록 다양성 확보
+     *
+     * @param representMenu 대표 메뉴
+     * @param alreadyRecommendedMenuTypes 이미 추천된 메뉴 타입 Set
+     * @return 다양성 점수 (0.0 or 0.5)
+     */
+    private double calculateMenuDiversityBoost(String representMenu, Set<String> alreadyRecommendedMenuTypes) {
+        if (representMenu == null || representMenu.isBlank()) {
+            return 0.0;
+        }
+
+        String menuType = classifyMenuType(representMenu);
+
+        // 이미 추천된 메뉴 타입이 아니면 가산점
+        if (!alreadyRecommendedMenuTypes.contains(menuType)) {
+            return 0.5;
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * 메뉴를 타입별로 분류
+     * 키워드 기반 단순 분류
+     */
+    private String classifyMenuType(String menu) {
+        if (menu == null || menu.isBlank()) {
+            return "기타";
+        }
+
+        String lowerMenu = menu.toLowerCase();
+
+        // 튀김류
+        if (lowerMenu.contains("돈카츠") || lowerMenu.contains("카츠") || lowerMenu.contains("튀김")
+                || lowerMenu.contains("가라아게") || lowerMenu.contains("텐동")) {
+            return "튀김류";
+        }
+        // 탕/국류
+        if (lowerMenu.contains("국밥") || lowerMenu.contains("탕") || lowerMenu.contains("찌개")
+                || lowerMenu.contains("전골") || lowerMenu.contains("샤브샤브")) {
+            return "탕류";
+        }
+        // 면류
+        if (lowerMenu.contains("면") || lowerMenu.contains("라멘") || lowerMenu.contains("우동")
+                || lowerMenu.contains("파스타") || lowerMenu.contains("짬뽕") || lowerMenu.contains("냉면")
+                || lowerMenu.contains("칼국수") || lowerMenu.contains("소바")) {
+            return "면류";
+        }
+        // 구이류
+        if (lowerMenu.contains("구이") || lowerMenu.contains("삼겹살") || lowerMenu.contains("갈비")
+                || lowerMenu.contains("스테이크") || lowerMenu.contains("바베큐") || lowerMenu.contains("불고기")) {
+            return "구이류";
+        }
+        // 회/생선류
+        if (lowerMenu.contains("회") || lowerMenu.contains("사시미") || lowerMenu.contains("스시")
+                || lowerMenu.contains("초밥") || lowerMenu.contains("오마카세")) {
+            return "회류";
+        }
+        // 볶음류
+        if (lowerMenu.contains("볶음") || lowerMenu.contains("덮밥") || lowerMenu.contains("비빔")) {
+            return "볶음류";
+        }
+        // 빵/디저트류
+        if (lowerMenu.contains("빵") || lowerMenu.contains("케이크") || lowerMenu.contains("디저트")
+                || lowerMenu.contains("브런치")) {
+            return "디저트류";
+        }
+        // 피자/양식
+        if (lowerMenu.contains("피자") || lowerMenu.contains("버거") || lowerMenu.contains("햄버거")) {
+            return "양식류";
+        }
+        // 치킨
+        if (lowerMenu.contains("치킨") || lowerMenu.contains("닭")) {
+            return "치킨류";
+        }
+
+        return "기타";
     }
 
     /**
@@ -604,6 +935,14 @@ public class RecommendationService {
 
         // 3. 알 수 없는 값
         return null;
+    }
+
+
+    /**
+     * 소수점 셋째 자리 반올림 유틸리티
+     */
+    private static double roundToThreeDecimals(double value) {
+        return Math.round(value * 1000.0) / 1000.0;
     }
 
     private void saveFailedResult(Long gatheringId, FailureReason reason, String errorMessage) {

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
@@ -4,6 +4,7 @@ import com.yogieat.common.GeoJson;
 import com.yogieat.common.Region;
 import com.yogieat.gathering.domain.value.TimeSlot;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record Restaurant(
         Long id,
@@ -25,7 +26,7 @@ public record Restaurant(
         Integer representMenuPrice,
         String priceLevel,
         String aiMateSummaryTitle,
-        String aiMateSummaryContents,  // JSON 문자열
+        List<String> aiMateSummaryContents,
         // 추천 시간대 (신규 필드)
         TimeSlot timeSlot,
         // 추천 알고리즘용 시간 데이터 (Cold Start, Freshness)

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
@@ -3,6 +3,7 @@ package com.yogieat.restaurant.domain;
 import com.yogieat.common.GeoJson;
 import com.yogieat.common.Region;
 import com.yogieat.gathering.domain.value.TimeSlot;
+import java.time.LocalDateTime;
 
 public record Restaurant(
         Long id,
@@ -26,6 +27,9 @@ public record Restaurant(
         String aiMateSummaryTitle,
         String aiMateSummaryContents,  // JSON 문자열
         // 추천 시간대 (신규 필드)
-        TimeSlot timeSlot
+        TimeSlot timeSlot,
+        // 추천 알고리즘용 시간 데이터 (Cold Start, Freshness)
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ){
 }

--- a/apps/domain/src/test/java/com/yogieat/restaurant/service/RestaurantValidatorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/service/RestaurantValidatorTest.java
@@ -117,6 +117,8 @@ class RestaurantValidatorTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
         );
     }

--- a/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncJobServiceTest.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncJobServiceTest.java
@@ -85,6 +85,8 @@ class RestaurantSyncJobServiceTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
         )));
         when(syncJobRepository.existsByTargetRestaurantIdAndStatus(1L, RestaurantSyncJobStatus.RUNNING)).thenReturn(false);
@@ -142,6 +144,8 @@ class RestaurantSyncJobServiceTest {
                 "name",
                 "address",
                 4.0,
+                null,
+                null,
                 null,
                 null,
                 null,

--- a/docs/architecture/recommendation-system.md
+++ b/docs/architecture/recommendation-system.md
@@ -1,0 +1,407 @@
+# 맛집 추천 시스템 아키텍처
+
+## 개요
+
+`RecommendationService.processRecommendation()` 메서드는 모임(Gathering)에 참여한 참가자들의 선호도를 분석하여 최적의 맛집 Top 3를 추천하는 핵심 비즈니스 로직입니다.
+
+---
+
+## 전체 처리 흐름
+
+```mermaid
+flowchart TD
+    A[processRecommendation 시작] --> B[1. 기존 레코드 확인<br/>중복 처리 방지]
+    B --> C[2. Gathering 조회<br/>TimeSlot 필터링용]
+    C --> D[3. 참여자 조회]
+    D --> E{참여자 존재?}
+    E -->|No| F[FAILED: NO_PARTICIPANTS]
+    E -->|Yes| G[4. Region 기반 Restaurant 조회]
+    G --> H{맛집 존재?}
+    H -->|No| I[FAILED: NO_RESTAURANTS]
+    H -->|Yes| J[5. Category 조회 및 캐싱]
+    J --> K[6. DistanceRange 다수결 결정]
+    K --> L[7. 선호도/불호 사전 집계]
+    L --> M[8. 불호 카테고리 추출]
+    M --> N[9. 지역 중심 좌표 조회]
+    N --> O[10. 다단계 Fallback Top 3 추천]
+    O --> P{추천 결과?}
+    P -->|Empty| Q[FAILED: NO_RESTAURANTS]
+    P -->|Found| R[11. RecommendResult 저장]
+    R --> S[COMPLETED]
+```
+
+---
+
+## 점수 계산 요소 및 가중치
+
+### 1. 선호도 점수 (Preference Score)
+
+참여자가 선택한 카테고리 순위에 따라 점수가 부여됩니다.
+
+| 순위 | 가중치 |
+|:----:|:------:|
+| 1순위 | **+3.0점** |
+| 2순위 | **+2.0점** |
+| 3순위 | **+1.0점** |
+
+**불호(Dislike) 페널티**: **-2.0점** (per dislike)
+
+**계산식**: `totalPreferenceScore - (dislikeCount × 2.0)`
+
+---
+
+### 2. 순수 선호수 가산점 (Net Preference Bonus)
+
+순수 선호수 = 선호자 수 - 불호자 수
+
+| 조건 | 가산점 |
+|:-----|:------:|
+| 순수 선호 > 0 | **+1.0점 × 순수 선호수** |
+| 순수 선호 = 0 (중립) | **-0.5점** |
+| 순수 선호 < 0 | **-2.0점 × |순수 선호수|** (강한 페널티) |
+
+---
+
+### 3. 신뢰도 점수 (Credibility Score)
+
+Wilson Score 기반 간소화 버전으로, 리뷰 수가 많고 평점이 높은 맛집을 우선합니다.
+**블로그 리뷰는 일반 리뷰보다 상세하므로 1.5배 가중치를 적용합니다.**
+
+```
+4.5점 100개 리뷰 > 5.0점 1개 리뷰
+```
+
+**계산식**:
+```java
+카카오 리뷰 가중치 = log₁₀(reviewCount + 1)
+// 100개 → 2.0, 1000개 → 3.0
+
+블로그 리뷰 가중치 = log₁₀(blogReviewCount + 1) × 1.5
+// 블로그 리뷰는 더 상세하므로 1.5배 가중
+
+총 리뷰 가중치 = min(카카오 가중치 + 블로그 가중치, 5.0)
+// 최대 5.0으로 제한
+
+정규화 평점 = (rating - 3.0) / 2.0
+// 3.0~5.0 → 0.0~1.0으로 정규화
+
+신뢰도 점수 = 정규화 평점 × 총 리뷰 가중치
+```
+
+---
+
+### 4. 거리 가산점 (Distance Bonus)
+
+참여자 다수결로 결정된 거리 범위 내에 위치한 맛집에 가산점을 부여합니다.
+
+| 거리 범위 | 조건 | 가산점 |
+|:----------|:-----|:------:|
+| RANGE_500M | 500m 이내 | **+1.0점** |
+| RANGE_1KM | 1km 이내 | **+1.0점** |
+| ANY | 제한 없음 | 가산점 없음 |
+
+**거리 다수결**: 참여자들의 `distanceRange` 값 중 가장 많이 선택된 값으로 결정
+
+---
+
+### 5. 의견일치율 가산점 (Agreement Rate Bonus)
+
+```
+의견일치율 = (해당 카테고리 선호자 수 / 총 참여자 수) × 100%
+가산점 = 의견일치율 / 100.0  (0~1점 범위)
+```
+
+예: 5명 중 3명이 한식 선택 → 60% → **+0.6점**
+
+---
+
+### 6. AI 요약 부스트 (AI Summary Boost)
+
+`aiMateSummaryContents` JSON 배열에서 키워드를 추출하여 그룹 특성과 매칭합니다.
+
+| 조건 | 가산점 |
+|:-----|:------:|
+| 참여자 4명 이상 + "단체석", "대형 테이블" 키워드 | **+0.5점** |
+| "추천", "인기", "맛집" 등 긍정 키워드 | **+0.3점** |
+| "웨이팅 필수", "예약 필수" 등 부정 키워드 | **-0.2점** |
+
+---
+
+### 7. 메뉴 다양성 부스트 (Menu Diversity Boost)
+
+Top 3 추천 시 메뉴 타입이 중복되지 않도록 **Post-processing Diversification** 패턴을 적용합니다.
+
+**알고리즘**:
+1. 다양성 부스트 없이 기본 점수로 상위 후보 10개 선정
+2. 후보 중에서 Greedy 방식으로 Top 3 선정 시 다양성 부스트 적용
+
+| 조건 | 가산점 |
+|:-----|:------:|
+| 이미 선택된 메뉴 타입과 다른 경우 | **+0.5점** |
+| 이미 선택된 메뉴 타입과 같은 경우 | 0점 |
+
+**메뉴 타입 분류**: 튀김류, 탕류, 면류, 구이류, 회류, 볶음류, 디저트류, 양식류, 치킨류, 기타
+
+> ⚠️ 이전 버전에서는 점수 계산과 타입 추적 시점이 불일치하여 순서 의존적인 버그가 있었습니다.
+> 현재 버전에서는 Post-processing 패턴을 적용하여 순서에 독립적인 결정을 보장합니다.
+
+---
+
+### 8. Cold Start 부스트 (Cold Start Boost)
+
+신규 맛집이 리뷰 부족으로 불이익을 받지 않도록 가산점을 부여합니다.
+
+**신규 맛집 판단 기준**:
+- 등록일(`createdAt`)이 **30일 이내**, 또는
+- 리뷰 수가 **10개 미만**
+
+**부스트 조건**:
+| 조건 | 가산점 |
+|:-----|:------:|
+| 신규 맛집 + 평점 ≥ 4.0 | **+0.3점** |
+| 신규 맛집 + 평점 < 4.0 | 0점 (관망) |
+| 기존 맛집 | 0점 |
+
+> 💡 평점이 좋은 신규 맛집에만 부스트를 적용하여, 잠재력 있는 맛집을 발굴합니다.
+
+---
+
+### 9. Freshness 부스트 (Freshness Boost)
+
+정보가 최신인 맛집을 우선하고, 오래된 정보에는 페널티를 부여합니다.
+
+**업데이트 시점 기준** (`updatedAt`):
+| 기간 | 부스트 |
+|:-----|:------:|
+| 7일 이내 | **+0.3점** (최신) |
+| 30일 이내 | **+0.1점** (보통) |
+| 30~90일 | 0점 |
+| 90일 이상 | **-0.2점** (정보 오래됨) |
+
+> 💡 카카오맵 동기화로 정보가 갱신되면 `updatedAt`이 업데이트되어 자동으로 Freshness 점수에 반영됩니다.
+
+---
+
+## 최종 점수 계산
+
+```
+totalScore = 선호도 점수
+           + 순수 선호수 가산점
+           + 신뢰도 점수 (blogReviewCount 반영)
+           + 거리 가산점 (범위 내: +1.0)
+           + 의견일치율 가산점 (0~1)
+           + AI 요약 부스트 (-0.2 ~ +0.8)
+           + Cold Start 부스트 (0 or +0.3)
+           + Freshness 부스트 (-0.2 ~ +0.3)
+           + 메뉴 다양성 부스트 (0 or +0.5, Post-processing 단계)
+```
+
+**소수점 셋째 자리 반올림** 적용
+
+### 점수 범위 요약
+
+| 요소 | 최소 | 최대 | 비고 |
+|:-----|:----:|:----:|:-----|
+| 선호도 점수 | 0 | +9.0 | 3명 모두 1순위 시 |
+| 순수 선호수 가산점 | -∞ | +∞ | 참여자 수에 비례 |
+| 신뢰도 점수 | 0 | +5.0 | 평점×리뷰가중치 |
+| 거리 가산점 | 0 | +1.0 | 범위 내 |
+| 의견일치율 가산점 | 0 | +1.0 | 100%일 때 |
+| AI 요약 부스트 | -0.2 | +0.8 | 키워드 매칭 |
+| Cold Start 부스트 | 0 | +0.3 | 신규 맛집 |
+| Freshness 부스트 | -0.2 | +0.3 | 정보 신선도 |
+| 메뉴 다양성 부스트 | 0 | +0.5 | Post-processing |
+
+---
+
+## 필터링 로직
+
+### TimeSlot 필터링 (최우선)
+
+모임의 시간대와 맛집의 운영 시간대가 호환되어야 합니다.
+
+| 모임 TimeSlot | 맛집 TimeSlot | 호환 여부 |
+|:--------------|:--------------|:---------:|
+| LUNCH | LUNCH | O |
+| LUNCH | DINNER | X |
+| LUNCH | BOTH | O |
+| DINNER | LUNCH | X |
+| DINNER | DINNER | O |
+| DINNER | BOTH | O |
+| BOTH | * | O (모두 허용) |
+
+---
+
+### 다단계 Fallback 전략
+
+```mermaid
+flowchart TD
+    A[추천 시작] --> B[1단계: PREFERENCE_SCORE_POSITIVE]
+    B --> C{선호도 점수 > 0?}
+    C -->|Yes| D{순수 선호수 >= -1?}
+    D -->|Yes| E[추천 대상 포함]
+    D -->|No| F[제외: 불호가 2명 이상 많음]
+    C -->|No| F
+    
+    E --> G{Top 3 결과 있음?}
+    G -->|Yes| H[추천 완료]
+    G -->|No| I[2단계: DISLIKED_EXCLUDED<br/>Fallback]
+    
+    I --> J{순수 선호수 >= -1?}
+    J -->|Yes| K[추천 대상 포함]
+    J -->|No| L[제외: 불호가 2명 이상 많음]
+    
+    K --> M[Top 3 추출]
+    M --> H
+```
+
+---
+
+## 추천 근거 텍스트 생성
+
+추천 결과와 함께 사용자에게 보여줄 근거 텍스트가 자동 생성됩니다.
+
+**형식**:
+```
+{총 참여자}명 중 {선호자 수}명이 {카테고리}을 골라서
+{AI 요약 타이틀}
+을(를) 추천해요
+```
+
+**예시**:
+```
+5명 중 3명이 일식을 골라서
+400시간 숙성으로 완성한 겉바속촉 돈카츠
+을(를) 추천해요
+```
+
+---
+
+## Top-K 알고리즘
+
+PriorityQueue(Min-Heap)를 사용하여 **O(N log K)** 시간 복잡도로 상위 3개 맛집을 추출합니다.
+
+```java
+if (heap.size() < 3) {
+    heap.offer(scored);
+} else if (scored.totalScore() > heap.peek().totalScore()) {
+    heap.poll();
+    heap.offer(scored);
+}
+```
+
+---
+
+## 성능 최적화
+
+### 선호도 사전 집계
+
+기존: O(R × P × 3) — 레스토랑마다 모든 참여자의 선호도 순회
+
+개선: O(P × 3) + O(R) — 선호도를 미리 Map으로 집계 후 레스토랑별 조회
+
+```java
+Map<String, PreferenceScore> preferenceScoreMap = aggregatePreferenceScores(participants);
+```
+
+### Category 캐싱
+
+Spring Cache를 적용하여 Category 조회 결과를 캐싱합니다.
+
+---
+
+## 관련 클래스
+
+| 클래스 | 역할 |
+|:-------|:-----|
+| `RecommendationService` | 추천 로직 핵심 서비스 |
+| `PreferenceScore` | 카테고리별 선호도 점수 값 객체 |
+| `ScoredRestaurant` | 점수가 계산된 레스토랑 래퍼 |
+| `ParticipantAnalyzer` | 참여자 분석 (거리 다수결 등) |
+| `RecommendResult` | 추천 결과 도메인 |
+
+---
+
+## 상수 정의 (RecommendationService)
+
+코드 가독성과 유지보수를 위해 모든 가중치와 임계값이 상수로 정의되어 있습니다.
+
+```java
+// 점수 가중치
+private static final double DISTANCE_BONUS = 1.0;
+private static final double DIVERSITY_BONUS = 0.5;
+
+// AI 요약 부스트
+private static final double AI_GROUP_BOOST = 0.5;
+private static final double AI_POSITIVE_BOOST = 0.3;
+private static final double AI_NEGATIVE_PENALTY = -0.2;
+private static final int GROUP_SIZE_THRESHOLD = 4;
+
+// Cold Start
+private static final int COLD_START_DAYS_THRESHOLD = 30;
+private static final int COLD_START_REVIEW_THRESHOLD = 10;
+private static final double COLD_START_RATING_THRESHOLD = 4.0;
+private static final double COLD_START_BOOST = 0.3;
+
+// Freshness
+private static final int FRESHNESS_RECENT_DAYS = 7;
+private static final int FRESHNESS_MODERATE_DAYS = 30;
+private static final int FRESHNESS_STALE_DAYS = 90;
+private static final double FRESHNESS_RECENT_BOOST = 0.3;
+private static final double FRESHNESS_MODERATE_BOOST = 0.1;
+private static final double FRESHNESS_STALE_PENALTY = -0.2;
+
+// 후보 선정
+private static final int CANDIDATE_POOL_SIZE = 10;
+private static final int TOP_K_SIZE = 3;
+```
+
+---
+
+## 실패 처리
+
+| FailureReason | 설명 |
+|:--------------|:-----|
+| `NO_PARTICIPANTS` | 참여자가 없음 |
+| `NO_RESTAURANTS` | 해당 지역에 맛집이 없거나 필터링 후 적합한 맛집이 없음 |
+| `PROCESSING_EXCEPTION` | 처리 중 예외 발생 |
+
+실패 시 `RecommendResultFailed` 테이블에 실패 사유와 함께 저장됩니다.
+
+---
+
+## 시퀀스 다이어그램
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant RS as RecommendationService
+    participant Repo as Repository
+    participant PA as ParticipantAnalyzer
+
+    User->>RS: processRecommendation(gatheringId, region)
+    
+    RS->>Repo: findByGatheringId()
+    Repo-->>RS: List<RecommendResult>
+    
+    RS->>Repo: findById(gatheringId)
+    Repo-->>RS: Gathering
+    
+    RS->>Repo: findByGatheringId(participants)
+    Repo-->>RS: List<Participant>
+    
+    RS->>Repo: findByRegion(region)
+    Repo-->>RS: List<Restaurant>
+    
+    RS->>PA: determineMajorityDistanceRange(participants)
+    PA-->>RS: DistanceRange
+    
+    Note over RS: aggregatePreferenceScores()
+    Note over RS: scoreAndFilterRestaurants()
+    Note over RS: 내부 점수 계산 및 Top 3 추출
+    
+    RS->>Repo: saveAll(results)
+    Repo-->>RS: saved
+    
+    RS-->>User: 추천 완료
+```

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
@@ -206,7 +206,10 @@ public class RestaurantEntity extends BaseEntity {
                 entity.getAiMateSummaryTitle(),
                 entity.getAiMateSummaryContents(),
                 // 추천 시간대
-                entity.getTimeSlot()
+                entity.getTimeSlot(),
+                // 추천 알고리즘용 시간 데이터
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
         );
     }
 

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
@@ -1,5 +1,7 @@
 package com.yogieat.datasource.db.core.restaurant;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yogieat.common.GeoJson;
 import com.yogieat.common.Region;
 import com.yogieat.datasource.db.core.common.BaseEntity;
@@ -13,16 +15,19 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.util.Collections;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 
+@Slf4j
 @Getter
 @Entity
 @Table(
@@ -64,6 +69,7 @@ import org.locationtech.jts.geom.PrecisionModel;
 public class RestaurantEntity extends BaseEntity {
     private static final GeometryFactory GEOMETRY_FACTORY =
             new GeometryFactory(new PrecisionModel(), 4326);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private String name;
     private String address;
@@ -204,7 +210,7 @@ public class RestaurantEntity extends BaseEntity {
                 entity.getRepresentMenuPrice(),
                 entity.getPriceLevel(),
                 entity.getAiMateSummaryTitle(),
-                entity.getAiMateSummaryContents(),
+                parseAiMateSummaryContents(entity.getAiMateSummaryContents()),
                 // 추천 시간대
                 entity.getTimeSlot(),
                 // 추천 알고리즘용 시간 데이터
@@ -216,6 +222,18 @@ public class RestaurantEntity extends BaseEntity {
     private static Point toJtsPoint(GeoJson.Point point) {
         List<Double> coordinates = point.getCoordinates();
         return GEOMETRY_FACTORY.createPoint(new Coordinate(coordinates.getFirst(), coordinates.get(1)));
+    }
+
+    private static List<String> parseAiMateSummaryContents(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return OBJECT_MAPPER.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            log.warn("Failed to parse aiMateSummaryContents: {}", json);
+            return Collections.emptyList();
+        }
     }
 
     public void applySyncPatch(RestaurantSyncPatch patch) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #85 

## 📌 작업 내용

- Restaurant 도메인에 createdAt, updatedAt 필드 추가 (Cold Start, Freshness 계산용)
- 추천 서비스 점수 계산 알고리즘 개선:
  - Cold Start 부스트: 신규 맛집(30일 이내 or 리뷰 10개 미만) + 평점 4.0 이상 시 가산점
  - Freshness 부스트: 최근 업데이트 맛집 가산점, 오래된 정보 페널티
  - AI 요약 부스트: 단체석/긍정 키워드 가산, 웨이팅 키워드 감점
  - 블로그 리뷰 반영: 신뢰도 점수에 blogReviewCount 1.5배 가중치 적용
  - Post-processing Diversification: 상위 10개 후보 중 메뉴 다양성 고려하여 Top 3 선정
- 테스트 코드 Restaurant 생성자 인자 수 맞춤
- 추천 시스템 아키텍처 문서 추가

## 📝 참고

- 

## 💬 리뷰 요구사항(선택)

-