### PR TITLE
[Fix] 과반수 인원 충족 여부 계산 로직 수정

### DIFF
--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendValidator.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendValidator.java
@@ -18,7 +18,7 @@ public class RecommendValidator {
      * @throws CustomException PARTICIPANT_MAJORITY_NOT_REACHED - 과반수 미달 시
      */
     public void validateMajorityReached(long currentCount, int peopleCount) {
-        if (currentCount * 2 <= peopleCount) {
+        if (currentCount * 2 < peopleCount) {
             throw new CustomException(ErrorCode.PARTICIPANT_MAJORITY_NOT_REACHED);
         }
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #136

## 📌 작업 내용

- 현재 인원수가 총 인원수의 절반을 차지했음에도 과반수로 측정되지 않는 이슈 해결
- `currentCount * 2 <= peopleCount` 👉🏻 `currentCount * 2 < peopleCount`로 수정

## 📝 참고

- 

## 💬 리뷰 요구사항(선택)

-