### PR TITLE
[Fix] 과반수 인원 충족 여부 계산 로직 롤백

### DIFF
--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendValidator.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendValidator.java
@@ -18,7 +18,7 @@ public class RecommendValidator {
      * @throws CustomException PARTICIPANT_MAJORITY_NOT_REACHED - 과반수 미달 시
      */
     public void validateMajorityReached(long currentCount, int peopleCount) {
-        if (currentCount * 2 < peopleCount) {
+        if (currentCount * 2 <= peopleCount) {
             throw new CustomException(ErrorCode.PARTICIPANT_MAJORITY_NOT_REACHED);
         }
     }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #138

## 📌 작업 내용

- 기존 과반수 계산 로직(`currentCount * 2 < peopleCount`)에서 총 인원의 절반만 있어도 과반으로 잘못 판단되는 이슈 발생
- 과반수는 총 인원의 절반을 초과하는 수를 의미하므로, 조건을 만족하지 않는 경우 예외를 던지도록 수정
- `currentCount * 2 < peopleCount` 👉🏻 `currentCount * 2 <= peopleCount`로 수정

## 📝 참고

- 

## 💬 리뷰 요구사항(선택)

-