### PR TITLE
[Feature] 모임 참여 닉네임 사전 중복 검증 API 구현

### DIFF
--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/ParticipantController.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/ParticipantController.java
@@ -1,6 +1,7 @@
 package com.yogieat.controller.v1.participant;
 
 import com.yogieat.controller.v1.participant.request.CreateParticipantRequest;
+import com.yogieat.controller.v1.participant.request.ValidateNicknameRequest;
 import com.yogieat.controller.v1.participant.response.CreateParticipantResponse;
 import com.yogieat.participant.service.ParticipantFacade;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ParticipantController {
     private final ParticipantFacade participantFacade;
+
+    // 닉네임 사전 중복 검증 API
+    @Operation(summary = "닉네임 중복 사전 검증", description = "모임 참여 전 닉네임 중복 여부를 사전에 검증합니다.")
+    @PostMapping("/nickname/validation")
+    public void validateNickname(
+            @RequestBody @Valid ValidateNicknameRequest request
+    ) {
+        participantFacade.validateNickname(request.accessKey(), request.nickname());
+    }
 
     // 참여 API
     @Operation(summary = "모임 참여", description = "사용자가 모임에 참여합니다.")

--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/ValidateNicknameRequest.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/ValidateNicknameRequest.java
@@ -1,0 +1,33 @@
+package com.yogieat.controller.v1.participant.request;
+
+import com.yogieat.common.error.CustomException;
+import com.yogieat.common.error.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.regex.Pattern;
+
+@Schema(description = "닉네임 중복 사전 검증 요청 정보")
+public record ValidateNicknameRequest(
+        @Schema(description = "모임 accessKey", example = "access-key")
+        String accessKey,
+        @Schema(description = "참여자 닉네임 (최대 8자)", example = "철수")
+        String nickname
+) {
+    private static final int MAX_NICKNAME_LENGTH = 8;
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ\\s]+$");
+
+    public ValidateNicknameRequest {
+        if (nickname == null || nickname.isBlank()) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
+        }
+
+        nickname = nickname.strip();
+
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
+        }
+
+        if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_INVALID);
+        }
+    }
+}

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
@@ -31,6 +31,14 @@ public class ParticipantFacade {
     private final RecommendResultService recommendResultService;
     private final GatheringEventNotifier gatheringEventNotifier;
 
+    @Transactional(readOnly = true)
+    public void validateNickname(String accessKey, String nickname) {
+        Gathering gathering = gatheringService.getGatheringByAccessKey(accessKey);
+        if (participantService.existsByGatheringIdAndNickname(gathering.id(), nickname)) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+
     @Transactional
     public ParticipantResult.Create participate(ParticipantCommand.Create command) {
         // Gathering별 락을 사용하여 동시성 제어


### PR DESCRIPTION
## 🌱 관련 이슈
- close #141

## 📌 작업 내용
- `POST /api/v1/participants/nickname/validation` 닉네임 사전 중복 검증 API 추가
  - `accessKey` 기준 모임 단위로 닉네임 중복 여부 확인
  - 닉네임 제약조건 검증: 필수값, 공백 포함 8자 이하, 숫자/특수문자 불가
  - 중복 시 `409 Conflict (DUPLICATE_NICKNAME)` 반환

## 📝 참고
- 닉네임 검증은 **선검증(API 호출) → 최종 검증(참여 로직 내)** 2단계로 분리
  - 선검증은 UX 목적(빠른 피드백), 최종 검증은 동시성 안전 보장 목적
- 닉네임 중복 기준은 **모임 단위(accessKey → gatheringId)**
- 닉네임 유효성 패턴: `^[a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ\s]+$` (기존 참여 API와 동일)

## 💬 리뷰 요구사항(선택)
- 
