### PR TITLE
[Refactor] 닉네임 중복 검증 책임을 ParticipantValidator로 이동

### DIFF
--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
@@ -5,7 +5,6 @@ import com.yogieat.common.error.ErrorCode;
 import com.yogieat.participant.domain.command.ParticipantCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import java.util.regex.Pattern;
 
 @Schema(description = "모임 참여 요청 정보")
 public record CreateParticipantRequest(
@@ -22,27 +21,13 @@ public record CreateParticipantRequest(
 ) {
     private static final int MAX_DISLIKES_SIZE = 2;
     private static final int MAX_PREFERENCES_SIZE = 3;
-    private static final int MAX_NICKNAME_LENGTH = 8;
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ\\s]+$");
 
     /**
-     * Compact constructor for validation.
-     * nickname: 최대 8자 (공백 포함), dislikes: 최소 1개, 최대 4개, preferences: 최대 3개까지만 허용
+     * Compact constructor for normalization and input boundary validation.
+     * 닉네임 형식 검증은 ParticipantValidator에서 수행한다.
      */
     public CreateParticipantRequest {
-        if (nickname == null || nickname.isBlank()) {
-            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
-        }
-
-        nickname = nickname.strip();
-
-        if (nickname.length() > MAX_NICKNAME_LENGTH) {
-            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
-        }
-
-        if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
-            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_INVALID);
-        }
+        nickname = nickname != null ? nickname.strip() : null;
 
         if (dislikes == null || dislikes.isEmpty() || dislikes.size() > MAX_DISLIKES_SIZE) {
             throw new CustomException(ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);

--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequest.java
@@ -23,11 +23,13 @@ public record CreateParticipantRequest(
     private static final int MAX_PREFERENCES_SIZE = 3;
 
     /**
-     * Compact constructor for normalization and input boundary validation.
-     * 닉네임 형식 검증은 ParticipantValidator에서 수행한다.
+     * Compact constructor for validation.
+     * dislikes: 최소 1개, 최대 2개, preferences: 최대 3개까지만 허용
      */
     public CreateParticipantRequest {
-        nickname = nickname != null ? nickname.strip() : null;
+        if (nickname != null) {
+            nickname = nickname.strip();
+        }
 
         if (dislikes == null || dislikes.isEmpty() || dislikes.size() > MAX_DISLIKES_SIZE) {
             throw new CustomException(ErrorCode.PARTICIPANT_DISLIKES_EXCEEDED);

--- a/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/ValidateNicknameRequest.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/participant/request/ValidateNicknameRequest.java
@@ -1,9 +1,6 @@
 package com.yogieat.controller.v1.participant.request;
 
-import com.yogieat.common.error.CustomException;
-import com.yogieat.common.error.ErrorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.regex.Pattern;
 
 @Schema(description = "닉네임 중복 사전 검증 요청 정보")
 public record ValidateNicknameRequest(
@@ -12,22 +9,9 @@ public record ValidateNicknameRequest(
         @Schema(description = "참여자 닉네임 (최대 8자)", example = "철수")
         String nickname
 ) {
-    private static final int MAX_NICKNAME_LENGTH = 8;
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ\\s]+$");
-
     public ValidateNicknameRequest {
-        if (nickname == null || nickname.isBlank()) {
-            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
-        }
-
-        nickname = nickname.strip();
-
-        if (nickname.length() > MAX_NICKNAME_LENGTH) {
-            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
-        }
-
-        if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
-            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_INVALID);
+        if (nickname != null) {
+            nickname = nickname.strip();
         }
     }
 }

--- a/apps/api/src/test/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequestTest.java
+++ b/apps/api/src/test/java/com/yogieat/controller/v1/participant/request/CreateParticipantRequestTest.java
@@ -34,6 +34,35 @@ class CreateParticipantRequestTest {
     }
 
     @Test
+    @DisplayName("닉네임 앞뒤 공백은 자동으로 제거된다")
+    void nicknameWithSurroundingSpaces_shouldBeStripped() {
+        // Given
+        String nickname = "  철수  ";
+        List<String> dislikes = List.of("양파");
+
+        // When
+        CreateParticipantRequest request =
+                CreateParticipantRequest.of("key", nickname, null, dislikes, null);
+
+        // Then
+        assertThat(request.nickname()).isEqualTo("철수");
+    }
+
+    @Test
+    @DisplayName("닉네임이 null이어도 DTO 생성에 성공한다 (형식 검증은 ParticipantValidator에서 수행)")
+    void nullNickname_shouldCreateSuccessfully() {
+        // Given
+        List<String> dislikes = List.of("양파");
+
+        // When
+        CreateParticipantRequest request =
+                CreateParticipantRequest.of("key", null, null, dislikes, null);
+
+        // Then
+        assertThat(request.nickname()).isNull();
+    }
+
+    @Test
     @DisplayName("dislikes가 null이면 예외가 발생한다")
     void dislikesNull_shouldThrowException() {
         // Given

--- a/apps/api/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
+++ b/apps/api/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
@@ -62,12 +62,13 @@ class ParticipantFacadeConcurrencyTest {
 
         // When: 10개 스레드가 동시에 참여 시도
         for (int i = 0; i < threadCount; i++) {
+            final int index = i;
             executor.submit(
                     () -> {
                         try {
                             ParticipantCommand.Create command =
                                     new ParticipantCommand.Create(
-                                            gathering.accessKey(), null, null, List.of(), List.of());
+                                            gathering.accessKey(), "참여자" + index, null, List.of(), List.of());
                             participantFacade.participate(command);
                             successCount.incrementAndGet();
                         } catch (CustomException e) {
@@ -110,7 +111,8 @@ class ParticipantFacadeConcurrencyTest {
                 () -> {
                     try {
                         startLatch.await();
-                        participantFacade.participate(createCommand(gathering1.accessKey()));
+                        participantFacade.participate(
+                                new ParticipantCommand.Create(gathering1.accessKey(), "참여자A", null, List.of(), List.of()));
                         successCount.incrementAndGet();
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
@@ -127,7 +129,8 @@ class ParticipantFacadeConcurrencyTest {
                 () -> {
                     try {
                         startLatch.await();
-                        participantFacade.participate(createCommand(gathering2.accessKey()));
+                        participantFacade.participate(
+                                new ParticipantCommand.Create(gathering2.accessKey(), "참여자B", null, List.of(), List.of()));
                         successCount.incrementAndGet();
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
@@ -155,11 +158,6 @@ class ParticipantFacadeConcurrencyTest {
         assertThat(participantRepository.countByGatheringId(gathering2.id())).isEqualTo(1);
     }
 
-    private Gathering createGathering(String title) {
-        GatheringEntity gatheringEntity = GatheringFixture.create(title, 4);
-        return gatheringRepository.save(GatheringEntity.toDomain(gatheringEntity));
-    }
-
     private Gathering createGatheringWithAccessKey(String accessKey, String title) {
         GatheringEntity gatheringEntity = GatheringFixture.create(
                 accessKey,
@@ -170,9 +168,5 @@ class ParticipantFacadeConcurrencyTest {
                 4
         );
         return gatheringRepository.save(GatheringEntity.toDomain(gatheringEntity));
-    }
-
-    private ParticipantCommand.Create createCommand(String accessKey) {
-        return new ParticipantCommand.Create(accessKey, null, null, List.of(), List.of());
     }
 }

--- a/apps/api/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
+++ b/apps/api/src/test/java/com/yogieat/domain/participant/service/ParticipantFacadeConcurrencyTest.java
@@ -66,9 +66,10 @@ class ParticipantFacadeConcurrencyTest {
             executor.submit(
                     () -> {
                         try {
+                            String nickname = "참여자" + (char) ('A' + index);
                             ParticipantCommand.Create command =
                                     new ParticipantCommand.Create(
-                                            gathering.accessKey(), "참여자" + index, null, List.of(), List.of());
+                                            gathering.accessKey(), nickname, null, List.of(), List.of());
                             participantFacade.participate(command);
                             successCount.incrementAndGet();
                         } catch (CustomException e) {

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
@@ -25,15 +25,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ParticipantFacade {
     private final ParticipantService participantService;
+    private final ParticipantValidator participantValidator;
     private final GatheringService gatheringService;
     private final LockManager lockManager;
     private final ApplicationEventPublisher eventPublisher;
     private final RecommendResultService recommendResultService;
     private final GatheringEventNotifier gatheringEventNotifier;
-    private final ParticipantValidator participantValidator;
 
     @Transactional(readOnly = true)
     public void validateNickname(String accessKey, String nickname) {
+        participantValidator.validateNicknameFormat(nickname);
         Gathering gathering = gatheringService.getGatheringByAccessKey(accessKey);
         participantValidator.validateNicknameDuplicate(gathering.id(), nickname);
     }
@@ -62,7 +63,8 @@ public class ParticipantFacade {
                     // 3. Gathering 참여 인원 초과 검증
                     gatheringService.validateGatheringNotFull(gathering, currentParticipantCount);
 
-                    // 3-1. 같은 모임 내 닉네임 중복 검증
+                    // 3-1. 닉네임 형식 및 중복 검증
+                    participantValidator.validateNicknameFormat(command.nickname());
                     participantValidator.validateNicknameDuplicate(gathering.id(), command.nickname());
 
                     // 4. Double distance를 DistanceRange로 변환 (null이면 ANY)

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
@@ -30,13 +30,12 @@ public class ParticipantFacade {
     private final ApplicationEventPublisher eventPublisher;
     private final RecommendResultService recommendResultService;
     private final GatheringEventNotifier gatheringEventNotifier;
+    private final ParticipantValidator participantValidator;
 
     @Transactional(readOnly = true)
     public void validateNickname(String accessKey, String nickname) {
         Gathering gathering = gatheringService.getGatheringByAccessKey(accessKey);
-        if (participantService.existsByGatheringIdAndNickname(gathering.id(), nickname)) {
-            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
-        }
+        participantValidator.validateNicknameDuplicate(gathering.id(), nickname);
     }
 
     @Transactional
@@ -64,11 +63,7 @@ public class ParticipantFacade {
                     gatheringService.validateGatheringNotFull(gathering, currentParticipantCount);
 
                     // 3-1. 같은 모임 내 닉네임 중복 검증
-                    if (command.nickname() != null &&
-                            participantService.existsByGatheringIdAndNickname(
-                                    gathering.id(), command.nickname())) {
-                        throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
-                    }
+                    participantValidator.validateNicknameDuplicate(gathering.id(), command.nickname());
 
                     // 4. Double distance를 DistanceRange로 변환 (null이면 ANY)
                     DistanceRange distanceRange = DistanceRange.fromDistance(command.distance());

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantValidator.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantValidator.java
@@ -2,6 +2,7 @@ package com.yogieat.participant.service;
 
 import com.yogieat.common.error.CustomException;
 import com.yogieat.common.error.ErrorCode;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,33 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ParticipantValidator {
+
+    private static final int MAX_NICKNAME_LENGTH = 8;
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z가-힣ㄱ-ㅎㅏ-ㅣ\\s]+$");
+
     private final ParticipantService participantService;
+
+    /**
+     * 닉네임 형식 검증 (null 여부, 최대 길이, 허용 문자)
+     *
+     * @param nickname 검증할 닉네임
+     * @throws CustomException PARTICIPANT_NICKNAME_REQUIRED - 닉네임이 null 또는 공백일 때
+     * @throws CustomException PARTICIPANT_NICKNAME_TOO_LONG - 닉네임이 최대 길이를 초과할 때
+     * @throws CustomException PARTICIPANT_NICKNAME_INVALID - 닉네임에 허용되지 않는 문자가 포함될 때
+     */
+    public void validateNicknameFormat(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
+        }
+
+        if (nickname.length() > MAX_NICKNAME_LENGTH) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
+        }
+
+        if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new CustomException(ErrorCode.PARTICIPANT_NICKNAME_INVALID);
+        }
+    }
 
     /**
      * 같은 모임 내 닉네임 중복 검증

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantValidator.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantValidator.java
@@ -1,0 +1,28 @@
+package com.yogieat.participant.service;
+
+import com.yogieat.common.error.CustomException;
+import com.yogieat.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Participant 관련 검증 컴포넌트
+ */
+@Component
+@RequiredArgsConstructor
+public class ParticipantValidator {
+    private final ParticipantService participantService;
+
+    /**
+     * 같은 모임 내 닉네임 중복 검증
+     *
+     * @param gatheringId 모임 ID
+     * @param nickname    검증할 닉네임
+     * @throws CustomException DUPLICATE_NICKNAME - 닉네임이 이미 존재할 때
+     */
+    public void validateNicknameDuplicate(Long gatheringId, String nickname) {
+        if (nickname != null && participantService.existsByGatheringIdAndNickname(gatheringId, nickname)) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+}

--- a/apps/domain/src/test/java/com/yogieat/participant/service/ParticipantValidatorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/participant/service/ParticipantValidatorTest.java
@@ -1,0 +1,63 @@
+package com.yogieat.participant.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.yogieat.common.error.CustomException;
+import com.yogieat.common.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ParticipantValidatorTest {
+
+    @Mock
+    private ParticipantService participantService;
+
+    @InjectMocks
+    private ParticipantValidator participantValidator;
+
+    @Test
+    @DisplayName("닉네임이 중복되면 예외가 발생한다")
+    void validateNicknameDuplicate_WhenDuplicate_ShouldThrowException() {
+        // Given
+        Long gatheringId = 1L;
+        String nickname = "테스트";
+        when(participantService.existsByGatheringIdAndNickname(gatheringId, nickname)).thenReturn(true);
+
+        // When & Then
+        assertThatThrownBy(() -> participantValidator.validateNicknameDuplicate(gatheringId, nickname))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DUPLICATE_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("닉네임이 중복되지 않으면 예외가 발생하지 않는다")
+    void validateNicknameDuplicate_WhenNotDuplicate_ShouldNotThrowException() {
+        // Given
+        Long gatheringId = 1L;
+        String nickname = "테스트";
+        when(participantService.existsByGatheringIdAndNickname(gatheringId, nickname)).thenReturn(false);
+
+        // When & Then
+        assertThatCode(() -> participantValidator.validateNicknameDuplicate(gatheringId, nickname))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("닉네임이 null이면 검증 없이 통과한다")
+    void validateNicknameDuplicate_WhenNicknameIsNull_ShouldNotThrowException() {
+        // Given
+        Long gatheringId = 1L;
+        String nickname = null;
+
+        // When & Then
+        assertThatCode(() -> participantValidator.validateNicknameDuplicate(gatheringId, nickname))
+                .doesNotThrowAnyException();
+    }
+}

--- a/apps/domain/src/test/java/com/yogieat/participant/service/ParticipantValidatorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/participant/service/ParticipantValidatorTest.java
@@ -103,6 +103,7 @@ class ParticipantValidatorTest {
     @Test
     @DisplayName("닉네임이 null이면 중복 검증 없이 통과한다")
     void validateNicknameDuplicate_WhenNicknameIsNull_ShouldNotThrowException() {
-        assertThatCode(() -> participantValidator.validateNicknameDuplicate(1L, null));
+        assertThatCode(() -> participantValidator.validateNicknameDuplicate(1L, null))
+                .doesNotThrowAnyException();
     }
 }

--- a/apps/domain/src/test/java/com/yogieat/participant/service/ParticipantValidatorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/participant/service/ParticipantValidatorTest.java
@@ -22,8 +22,59 @@ class ParticipantValidatorTest {
     @InjectMocks
     private ParticipantValidator participantValidator;
 
+    // ── validateNicknameFormat ──────────────────────────────────────────────
+
     @Test
-    @DisplayName("닉네임이 중복되면 예외가 발생한다")
+    @DisplayName("정상 닉네임이면 예외가 발생하지 않는다")
+    void validateNicknameFormat_ValidNickname_ShouldNotThrow() {
+        assertThatCode(() -> participantValidator.validateNicknameFormat("철수"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("닉네임이 null이면 PARTICIPANT_NICKNAME_REQUIRED 예외가 발생한다")
+    void validateNicknameFormat_NullNickname_ShouldThrowRequired() {
+        assertThatThrownBy(() -> participantValidator.validateNicknameFormat(null))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("닉네임이 공백이면 PARTICIPANT_NICKNAME_REQUIRED 예외가 발생한다")
+    void validateNicknameFormat_BlankNickname_ShouldThrowRequired() {
+        assertThatThrownBy(() -> participantValidator.validateNicknameFormat("   "))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NICKNAME_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("닉네임이 8자를 초과하면 PARTICIPANT_NICKNAME_TOO_LONG 예외가 발생한다")
+    void validateNicknameFormat_TooLongNickname_ShouldThrowTooLong() {
+        assertThatThrownBy(() -> participantValidator.validateNicknameFormat("닉네임이너무길어요"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NICKNAME_TOO_LONG);
+    }
+
+    @Test
+    @DisplayName("닉네임에 숫자가 포함되면 PARTICIPANT_NICKNAME_INVALID 예외가 발생한다")
+    void validateNicknameFormat_NicknameWithNumber_ShouldThrowInvalid() {
+        assertThatThrownBy(() -> participantValidator.validateNicknameFormat("철수123"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NICKNAME_INVALID);
+    }
+
+    @Test
+    @DisplayName("닉네임에 특수문자가 포함되면 PARTICIPANT_NICKNAME_INVALID 예외가 발생한다")
+    void validateNicknameFormat_NicknameWithSpecialChar_ShouldThrowInvalid() {
+        assertThatThrownBy(() -> participantValidator.validateNicknameFormat("철수!"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NICKNAME_INVALID);
+    }
+
+    // ── validateNicknameDuplicate ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("닉네임이 중복되면 DUPLICATE_NICKNAME 예외가 발생한다")
     void validateNicknameDuplicate_WhenDuplicate_ShouldThrowException() {
         // Given
         Long gatheringId = 1L;
@@ -50,14 +101,8 @@ class ParticipantValidatorTest {
     }
 
     @Test
-    @DisplayName("닉네임이 null이면 검증 없이 통과한다")
+    @DisplayName("닉네임이 null이면 중복 검증 없이 통과한다")
     void validateNicknameDuplicate_WhenNicknameIsNull_ShouldNotThrowException() {
-        // Given
-        Long gatheringId = 1L;
-        String nickname = null;
-
-        // When & Then
-        assertThatCode(() -> participantValidator.validateNicknameDuplicate(gatheringId, nickname))
-                .doesNotThrowAnyException();
+        assertThatCode(() -> participantValidator.validateNicknameDuplicate(1L, null));
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #144

## 📌 작업 내용
- `ParticipantValidator` 신규 생성
  - 닉네임 중복 검증 로직(`validateNicknameDuplicate`)을 `ParticipantFacade`에서 분리
- `ParticipantFacade` 리팩토링
  - `validateNickname()`, `participate()` 양쪽에 인라인으로 작성되어 있던 닉네임 중복 검증을 `ParticipantValidator`로 위임
- `ParticipantValidatorTest` 신규 작성
  - 닉네임 중복 / 미중복 / null 케이스 단위 테스트 추가

## 📝 참고
- 

## 💬 리뷰 요구사항(선택)
- 