### PR TITLE
[Refactor] 추천 결과 생성 시 SSE 이벤트가 발행됨에 따른 네이밍 수정

### DIFF
--- a/apps/admin/src/main/java/com/yogieat/config/gathering/AdminGatheringEventNotifierConfig.java
+++ b/apps/admin/src/main/java/com/yogieat/config/gathering/AdminGatheringEventNotifierConfig.java
@@ -19,7 +19,7 @@ public class AdminGatheringEventNotifierConfig {
             }
 
             @Override
-            public void notifyGatheringFull(String accessKey, GatheringResult.ParticipantCount status) {
+            public void notifyRecommendResultCreated(String accessKey, GatheringResult.ParticipantCount status) {
                 // Admin app does not publish SSE events.
             }
         };

--- a/apps/api/src/main/java/com/yogieat/sse/SseGatheringEventNotifier.java
+++ b/apps/api/src/main/java/com/yogieat/sse/SseGatheringEventNotifier.java
@@ -19,8 +19,8 @@ public class SseGatheringEventNotifier implements GatheringEventNotifier {
     }
 
     @Override
-    public void notifyGatheringFull(String accessKey, GatheringResult.ParticipantCount status) {
-        sseEmitterManager.send(accessKey, "gathering-full",
+    public void notifyRecommendResultCreated(String accessKey, GatheringResult.ParticipantCount status) {
+        sseEmitterManager.send(accessKey, "recommend-result-created",
                 GetParticipantCountResponse.from(status));
         sseEmitterManager.complete(accessKey);
     }

--- a/apps/domain/src/main/java/com/yogieat/gathering/service/GatheringEventNotifier.java
+++ b/apps/domain/src/main/java/com/yogieat/gathering/service/GatheringEventNotifier.java
@@ -4,5 +4,5 @@ import com.yogieat.gathering.domain.result.GatheringResult;
 
 public interface GatheringEventNotifier {
     void notifyParticipantJoined(String accessKey, GatheringResult.ParticipantCount status);
-    void notifyGatheringFull(String accessKey, GatheringResult.ParticipantCount status);
+    void notifyRecommendResultCreated(String accessKey, GatheringResult.ParticipantCount status);
 }

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
@@ -96,7 +96,7 @@ public class ParticipantFacade {
                         recommendResultService.createPendingStatus(gathering.id());
 
                         log.info("Publishing RecommendResultCreatedEvent for gathering: {}", gathering.id());
-                        eventPublisher.publishEvent(new RecommendResultCreatedEvent(
+                        eventPublisher.publishEvent(RecommendResultCreatedEvent.of(
                                 this,
                                 gathering.id(),
                                 gathering.region(),

--- a/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/participant/service/ParticipantFacade.java
@@ -10,7 +10,7 @@ import com.yogieat.participant.domain.Participant;
 import com.yogieat.participant.domain.command.ParticipantCommand;
 import com.yogieat.participant.domain.result.ParticipantResult;
 import com.yogieat.participant.domain.value.DistanceRange;
-import com.yogieat.recommend.event.GatheringFullEvent;
+import com.yogieat.recommend.event.RecommendResultCreatedEvent;
 import com.yogieat.recommend.service.RecommendResultService;
 import com.yogieat.util.LockManager;
 import com.yogieat.util.StringUtils;
@@ -92,17 +92,17 @@ public class ParticipantFacade {
                     if (newCount == gathering.peopleCount()) {
                         log.info("Gathering is full. Creating PENDING status for gathering: {}", gathering.id());
 
-                        gatheringEventNotifier.notifyGatheringFull(command.accessKey(), status);
-
                         // PENDING 레코드 생성 (동기적)
                         recommendResultService.createPendingStatus(gathering.id());
 
-                        log.info("Publishing GatheringFullEvent for gathering: {}", gathering.id());
-                        eventPublisher.publishEvent(new GatheringFullEvent(
+                        log.info("Publishing RecommendResultCreatedEvent for gathering: {}", gathering.id());
+                        eventPublisher.publishEvent(new RecommendResultCreatedEvent(
                                 this,
                                 gathering.id(),
                                 gathering.region(),
-                                gathering.peopleCount()
+                                gathering.peopleCount(),
+                                command.accessKey(),
+                                newCount
                         ));
                     }
 

--- a/apps/domain/src/main/java/com/yogieat/recommend/event/RecommendResultCreatedEvent.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/event/RecommendResultCreatedEvent.java
@@ -12,12 +12,16 @@ public class RecommendResultCreatedEvent extends ApplicationEvent {
     private final String accessKey;
     private final long currentCount;
 
-    public RecommendResultCreatedEvent(Object source, Long gatheringId, Region region, Integer peopleCount, String accessKey, long currentCount) {
+    private RecommendResultCreatedEvent(Object source, Long gatheringId, Region region, Integer peopleCount, String accessKey, long currentCount) {
         super(source);
         this.gatheringId = gatheringId;
         this.region = region;
         this.peopleCount = peopleCount;
         this.accessKey = accessKey;
         this.currentCount = currentCount;
+    }
+
+    public static RecommendResultCreatedEvent of(Object source, Long gatheringId, Region region, Integer peopleCount, String accessKey, long currentCount) {
+        return new RecommendResultCreatedEvent(source, gatheringId, region, peopleCount, accessKey, currentCount);
     }
 }

--- a/apps/domain/src/main/java/com/yogieat/recommend/event/RecommendResultCreatedEvent.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/event/RecommendResultCreatedEvent.java
@@ -5,15 +5,19 @@ import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class GatheringFullEvent extends ApplicationEvent {
+public class RecommendResultCreatedEvent extends ApplicationEvent {
     private final Long gatheringId;
     private final Region region;
     private final Integer peopleCount;
+    private final String accessKey;
+    private final long currentCount;
 
-    public GatheringFullEvent(Object source, Long gatheringId, Region region, Integer peopleCount) {
+    public RecommendResultCreatedEvent(Object source, Long gatheringId, Region region, Integer peopleCount, String accessKey, long currentCount) {
         super(source);
         this.gatheringId = gatheringId;
         this.region = region;
         this.peopleCount = peopleCount;
+        this.accessKey = accessKey;
+        this.currentCount = currentCount;
     }
 }

--- a/apps/domain/src/main/java/com/yogieat/recommend/event/RecommendationEventListener.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/event/RecommendationEventListener.java
@@ -1,5 +1,7 @@
 package com.yogieat.recommend.event;
 
+import com.yogieat.gathering.domain.result.GatheringResult;
+import com.yogieat.gathering.service.GatheringEventNotifier;
 import com.yogieat.recommend.service.RecommendationProcessor;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -15,13 +17,18 @@ public class RecommendationEventListener {
     private static final Logger log = LoggerFactory.getLogger(RecommendationEventListener.class);
 
     private final RecommendationProcessor recommendationProcessor;
+    private final GatheringEventNotifier gatheringEventNotifier;
 
     @Async
     @TransactionalEventListener
-    public void handleGatheringFullEvent(GatheringFullEvent event) {
+    public void handleRecommendResultCreatedEvent(RecommendResultCreatedEvent event) {
         try {
             recommendationProcessor.processRecommendation(event.getGatheringId(), event.getRegion());
             log.info("Successfully processed recommendation for gathering: {}", event.getGatheringId());
+
+            GatheringResult.ParticipantCount status =
+                    GatheringResult.ParticipantCount.of(event.getCurrentCount(), event.getPeopleCount());
+            gatheringEventNotifier.notifyRecommendResultCreated(event.getAccessKey(), status);
 
         } catch (Exception e) {
             log.error("Failed to process recommendation for gathering: {}",

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
@@ -6,8 +6,6 @@ import com.yogieat.common.Region;
 import com.yogieat.common.error.CustomException;
 import com.yogieat.common.error.ErrorCode;
 import com.yogieat.gathering.domain.Gathering;
-import com.yogieat.gathering.domain.result.GatheringResult;
-import com.yogieat.gathering.service.GatheringEventNotifier;
 import com.yogieat.gathering.service.GatheringService;
 import com.yogieat.participant.domain.Participant;
 import com.yogieat.participant.domain.value.DistanceRange;
@@ -17,7 +15,7 @@ import com.yogieat.recommend.domain.RecommendResult;
 import com.yogieat.recommend.domain.result.RecommendResultData;
 import com.yogieat.recommend.domain.value.CategoryAggregation;
 import com.yogieat.recommend.domain.value.RecommendStatus;
-import com.yogieat.recommend.event.GatheringFullEvent;
+import com.yogieat.recommend.event.RecommendResultCreatedEvent;
 import com.yogieat.restaurant.domain.Restaurant;
 import com.yogieat.restaurant.service.RestaurantService;
 import com.yogieat.util.LockManager;
@@ -46,7 +44,6 @@ public class RecommendResultFacade {
     private final ParticipantAnalyzer participantAnalyzer;
     private final LockManager lockManager;
     private final ApplicationEventPublisher eventPublisher;
-    private final GatheringEventNotifier gatheringEventNotifier;
     private final RecommendValidator recommendValidator;
 
     @Transactional(readOnly = true)
@@ -124,16 +121,11 @@ public class RecommendResultFacade {
             recommendValidator.validateNotAlreadyProceeded(
                     recommendResultService.existsByGatheringId(gathering.id()));
 
-            // 5. SSE 알림
-            GatheringResult.ParticipantCount status =
-                    GatheringResult.ParticipantCount.of(currentCount, gathering.peopleCount());
-            gatheringEventNotifier.notifyGatheringFull(accessKey, status);
-
-            // 6. PENDING 상태 생성 및 이벤트 발행
+            // 5. PENDING 상태 생성 및 이벤트 발행
             recommendResultService.createPendingStatus(gathering.id());
-            log.info("Publishing GatheringFullEvent by majority for gathering: {}", gathering.id());
-            eventPublisher.publishEvent(new GatheringFullEvent(
-                    this, gathering.id(), gathering.region(), gathering.peopleCount()
+            log.info("Publishing RecommendResultCreatedEvent by majority for gathering: {}", gathering.id());
+            eventPublisher.publishEvent(new RecommendResultCreatedEvent(
+                    this, gathering.id(), gathering.region(), gathering.peopleCount(), accessKey, currentCount
             ));
             return null;
         });

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
@@ -124,7 +124,7 @@ public class RecommendResultFacade {
             // 5. PENDING 상태 생성 및 이벤트 발행
             recommendResultService.createPendingStatus(gathering.id());
             log.info("Publishing RecommendResultCreatedEvent by majority for gathering: {}", gathering.id());
-            eventPublisher.publishEvent(new RecommendResultCreatedEvent(
+            eventPublisher.publishEvent(RecommendResultCreatedEvent.of(
                     this, gathering.id(), gathering.region(), gathering.peopleCount(), accessKey, currentCount
             ));
             return null;

--- a/batch/sync/src/main/java/com/yogieat/config/gathering/SyncGatheringEventNotifierConfig.java
+++ b/batch/sync/src/main/java/com/yogieat/config/gathering/SyncGatheringEventNotifierConfig.java
@@ -19,7 +19,7 @@ public class SyncGatheringEventNotifierConfig {
             }
 
             @Override
-            public void notifyGatheringFull(String accessKey, GatheringResult.ParticipantCount status) {
+            public void notifyRecommendResultCreated(String accessKey, GatheringResult.ParticipantCount status) {
                 // Sync app does not publish SSE events.
             }
         };


### PR DESCRIPTION
## 🌱 관련 이슈
- close #142

## 📌 작업 내용
- `GatheringFullEvent` → `RecommendResultCreatedEvent` 네이밍 수정 (파일명/클래스명 전체)
- 이벤트에 `accessKey`, `currentCount` 필드 추가
- SSE 이벤트 타입 변경: `"gathering-full"` → `"recommend-result-created"`
- SSE 알림 발송 위치 변경: `ParticipantFacade`/`RecommendResultFacade` → `RecommendationEventListener` (추천 처리 완료 후 발송)

## 📝 참고
- 이벤트 발행 시점이 "인원 충족" → "추천 결과 생성 완료"로 변경된 구조에 맞춰 네이밍 정합성 확보

## 💬 리뷰 요구사항(선택)
- 