### PR TITLE
[Feature] 맛집 추천 시 휴무일 필터링 기능 구현

### DIFF
--- a/apps/api/src/test/java/com/yogieat/region/RegionMigrationIntegrationTest.java
+++ b/apps/api/src/test/java/com/yogieat/region/RegionMigrationIntegrationTest.java
@@ -267,7 +267,8 @@ class RegionMigrationIntegrationTest {
                 "MEDIUM",
                 "요약 제목",
                 "[\"요약\"]",
-                TimeSlot.LUNCH
+                TimeSlot.LUNCH,
+                null
         );
     }
 

--- a/apps/domain/src/main/java/com/yogieat/external/kakao/result/KakaoPlaceDetailData.java
+++ b/apps/domain/src/main/java/com/yogieat/external/kakao/result/KakaoPlaceDetailData.java
@@ -64,7 +64,7 @@ public record KakaoPlaceDetailData(
                 null,
                 null,
                 null,
-                List.of()
+                null
         );
     }
 }

--- a/apps/domain/src/main/java/com/yogieat/external/kakao/result/KakaoPlaceDetailData.java
+++ b/apps/domain/src/main/java/com/yogieat/external/kakao/result/KakaoPlaceDetailData.java
@@ -2,6 +2,7 @@ package com.yogieat.external.kakao.result;
 
 import com.yogieat.category.domain.value.LargeCategory;
 import com.yogieat.gathering.domain.value.TimeSlot;
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -33,7 +34,9 @@ public record KakaoPlaceDetailData(
         String apiCategoryName3,
         // 카카오 API에서 추출한 카테고리 정보
         LargeCategory apiLargeCategory,
-        String apiMediumCategory
+        String apiMediumCategory,
+        // 휴무일
+        List<LocalDate> offDays
 ) {
     /**
      * Create a minimal detail data when panel3 call fails
@@ -60,7 +63,8 @@ public record KakaoPlaceDetailData(
                 null,
                 null,
                 null,
-                null
+                null,
+                List.of()
         );
     }
 }

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
@@ -24,6 +24,7 @@ import com.yogieat.recommend.domain.value.ScoredRestaurant;
 import com.yogieat.recommend.service.strategy.RecommendationSelectionStrategy;
 import com.yogieat.restaurant.domain.Restaurant;
 import com.yogieat.restaurant.service.RestaurantRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -162,20 +163,14 @@ public class RecommendationProcessor {
             );
         }
 
+        LocalDate scheduledDate = gathering != null ? gathering.scheduledDate() : null;
         List<Restaurant> restaurants = findRecommendationCandidates(
                 region,
                 candidateCategoryIds,
                 gatheringTimeSlot,
-                excludedRestaurantIds
+                excludedRestaurantIds,
+                scheduledDate
         );
-
-        restaurants = restaurants.stream()
-                .filter(r -> {
-                    if (r.offDays() == null || r.offDays().isEmpty()) return true;
-                    if (gathering == null) return true;
-                    return !r.offDays().contains(gathering.scheduledDate());
-                })
-                .toList();
 
         if (restaurants.isEmpty()) {
             return RecommendationCandidateResult.failure(
@@ -208,21 +203,15 @@ public class RecommendationProcessor {
             Region region,
             Set<Long> candidateCategoryIds,
             TimeSlot gatheringTimeSlot,
-            List<Long> excludedRestaurantIds
+            List<Long> excludedRestaurantIds,
+            LocalDate scheduledDate
     ) {
-        if (excludedRestaurantIds == null || excludedRestaurantIds.isEmpty()) {
-            return restaurantRepository.findRecommendationCandidates(
-                    region,
-                    candidateCategoryIds,
-                    gatheringTimeSlot
-            );
-        }
-
         return restaurantRepository.findRecommendationCandidates(
                 region,
                 candidateCategoryIds,
                 gatheringTimeSlot,
-                excludedRestaurantIds
+                excludedRestaurantIds == null ? List.of() : excludedRestaurantIds,
+                scheduledDate
         );
     }
 

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
@@ -69,7 +69,7 @@ public class RecommendationProcessor {
                 // PENDING이 아닌 경우 (COMPLETED/FAILED) 재처리 방지
                 if (currentStatus != RecommendStatus.PENDING) {
                     log.info("Recommendation already processed for gathering: {} with status: {}",
-                             gatheringId, currentStatus);
+                            gatheringId, currentStatus);
                     return;
                 }
 
@@ -124,7 +124,7 @@ public class RecommendationProcessor {
             }
 
             saveFailedResult(gatheringId, FailureReason.PROCESSING_EXCEPTION,
-                             e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+                    e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
         }
     }
 
@@ -168,6 +168,15 @@ public class RecommendationProcessor {
                 gatheringTimeSlot,
                 excludedRestaurantIds
         );
+
+        restaurants = restaurants.stream()
+                .filter(r -> {
+                    if (r.offDays() == null || r.offDays().isEmpty()) return true;
+                    if (gathering == null) return true;
+                    return !r.offDays().contains(gathering.scheduledDate());
+                })
+                .toList();
+
         if (restaurants.isEmpty()) {
             return RecommendationCandidateResult.failure(
                     FailureReason.NO_RESTAURANTS,
@@ -280,9 +289,9 @@ public class RecommendationProcessor {
 
         // 점수 계산은 1회만 수행하고, 필터 전략만 다르게 적용
         List<CategoryScoredRestaurant> scoredCandidates = scoreRestaurants(
-            restaurants, categoryMap, participantContext,
-            participants, centerPoint,
-            gatheringTimeSlot
+                restaurants, categoryMap, participantContext,
+                participants, centerPoint,
+                gatheringTimeSlot
         );
 
         // 1단계: 선호도 점수 > 0인 레스토랑만
@@ -354,8 +363,8 @@ public class RecommendationProcessor {
             }
 
             PreferenceScore preferenceScore = preferenceScoreMap.getOrDefault(
-                categoryName,
-                PreferenceScore.empty()
+                    categoryName,
+                    PreferenceScore.empty()
             );
 
             // 기본 점수 계산 (다양성 부스트 제외)
@@ -808,8 +817,8 @@ public class RecommendationProcessor {
         // 1. 참여자 선호 정보
         if (preferenceCount > 0 && totalParticipants > 1) {
             sb.append(totalParticipants).append("명 중 ")
-              .append(preferenceCount).append("명이 ")
-              .append(categoryName).append("을 골라서\n");
+                    .append(preferenceCount).append("명이 ")
+                    .append(categoryName).append("을 골라서\n");
         }
 
         // 2. AI 요약 타이틀 (있는 경우)

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
@@ -96,8 +96,11 @@ public record CreateRestaurant(
     }
 
     private static String offDaysToJson(List<LocalDate> offDays) {
-        if (offDays == null || offDays.isEmpty()) {
+        if (offDays == null) {
             return null;
+        }
+        if (offDays.isEmpty()) {
+            return "[]";
         }
         return toJson(offDays.stream().map(LocalDate::toString).toList());
     }

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
@@ -6,6 +6,7 @@ import com.yogieat.common.GeoJson;
 import com.yogieat.common.Region;
 import com.yogieat.external.kakao.result.KakaoPlaceDetailData;
 import com.yogieat.gathering.domain.value.TimeSlot;
+import java.time.LocalDate;
 import java.util.List;
 
 public record CreateRestaurant(
@@ -29,7 +30,9 @@ public record CreateRestaurant(
         String aiMateSummaryTitle,
         String aiMateSummaryContents,  // JSON 문자열로 저장
         // 추천 시간대 (신규 필드)
-        TimeSlot timeSlot
+        TimeSlot timeSlot,
+        // 휴무일
+        String offDays  // JSON 문자열로 저장
 ) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -53,10 +56,10 @@ public record CreateRestaurant(
             String aiMateSummaryTitle,
             List<String> aiMateSummaryContents,
             // 추천 시간대 파라미터
-            TimeSlot timeSlot
+            TimeSlot timeSlot,
+            // 휴무일 파라미터
+            List<LocalDate> offDays
     ) {
-        String aiMateSummaryContentsJson = toJson(aiMateSummaryContents);
-
         return new CreateRestaurant(
                 externalId,
                 categoryId,
@@ -75,20 +78,28 @@ public record CreateRestaurant(
                 representMenuPrice,
                 priceLevel,
                 aiMateSummaryTitle,
-                aiMateSummaryContentsJson,
-                timeSlot
+                toJson(aiMateSummaryContents),
+                timeSlot,
+                offDaysToJson(offDays)
         );
     }
 
-    private static String toJson(List<String> aiMateSummaryContents) {
-        if (aiMateSummaryContents == null || aiMateSummaryContents.isEmpty()) {
+    private static String toJson(List<String> values) {
+        if (values == null || values.isEmpty()) {
             return null;
         }
         try {
-            return OBJECT_MAPPER.writeValueAsString(aiMateSummaryContents);
+            return OBJECT_MAPPER.writeValueAsString(values);
         } catch (JsonProcessingException e) {
             return null;
         }
+    }
+
+    private static String offDaysToJson(List<LocalDate> offDays) {
+        if (offDays == null || offDays.isEmpty()) {
+            return null;
+        }
+        return toJson(offDays.stream().map(LocalDate::toString).toList());
     }
 
     public static CreateRestaurant fromKakaoPlaceDetail(
@@ -124,7 +135,8 @@ public record CreateRestaurant(
                 detail == null ? null : detail.priceLevel(),
                 detail == null ? null : detail.aiMateSummaryTitle(),
                 toJson(detail == null ? null : detail.aiMateSummaryContents()),
-                detail == null ? null : detail.timeSlot()
+                detail == null ? null : detail.timeSlot(),
+                offDaysToJson(detail == null ? null : detail.offDays())
         );
     }
 

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
@@ -3,6 +3,7 @@ package com.yogieat.restaurant.domain;
 import com.yogieat.common.GeoJson;
 import com.yogieat.common.Region;
 import com.yogieat.gathering.domain.value.TimeSlot;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -31,6 +32,8 @@ public record Restaurant(
         TimeSlot timeSlot,
         // 추천 알고리즘용 시간 데이터 (Cold Start, Freshness)
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        // 휴무일
+        List<LocalDate> offDays
 ){
 }

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionProcessor.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionProcessor.java
@@ -52,24 +52,24 @@ public class RestaurantCollectionProcessor {
      * Place enum을 지역 정보의 단일 진실 공급원(SSOT)으로 사용
      */
     private static final List<String> LOCATIONS = Arrays.stream(Region.values())
-        .map(Region::getName)
-        .toList();
+            .map(Region::getName)
+            .toList();
 
     /**
      * LargeCategory enum에서 ANY를 제외한 음식 카테고리 목록
      * displayName을 사용하여 Gemini 프롬프트에 활용
      */
     private static final List<String> FOOD_CATEGORIES = Arrays.stream(LargeCategory.values())
-        .filter(category -> category != LargeCategory.ANY)
-        .map(LargeCategory::getDisplayName)
-        .toList();
+            .filter(category -> category != LargeCategory.ANY)
+            .map(LargeCategory::getDisplayName)
+            .toList();
 
     /**
      * Enum 변환 캐시: Place name → Place enum
      * 매번 stream().filter()를 사용하지 않고 O(1) 조회
      */
     private static final Map<String, Region> PLACE_CACHE = Arrays.stream(Region.values())
-        .collect(Collectors.toMap(Region::getName, Function.identity()));
+            .collect(Collectors.toMap(Region::getName, Function.identity()));
 
     private static final int RESTAURANTS_PER_REQUEST = 10;
     private static final int KAKAO_COLLECTION_CONCURRENT_PERMITS = 3;
@@ -81,14 +81,14 @@ public class RestaurantCollectionProcessor {
      * 나머지 지역: 50개
      */
     private static final Map<Region, Integer> REGION_LIMITS = Map.of(
-        Region.GANGNAM, 100,
-        Region.HONGDAE, 100,
-        Region.GONGDEOK, 50,
-        Region.EULJIRO3GA, 50,
-        Region.SADANG, 50,
-        Region.JONGNO3GA, 50,
-        Region.JAMSIL, 50,
-        Region.SAMGAKJI, 50
+            Region.GANGNAM, 100,
+            Region.HONGDAE, 100,
+            Region.GONGDEOK, 50,
+            Region.EULJIRO3GA, 50,
+            Region.SADANG, 50,
+            Region.JONGNO3GA, 50,
+            Region.JAMSIL, 50,
+            Region.SAMGAKJI, 50
     );
     private static final int DEFAULT_REGION_LIMIT = 50;
 
@@ -105,11 +105,11 @@ public class RestaurantCollectionProcessor {
 
             List<Restaurant> restaurants = restaurantRepository.findAll();
             String restaurantNames = restaurants.stream()
-                .map(Restaurant::name)
-                .collect(Collectors.joining(", "));
+                    .map(Restaurant::name)
+                    .collect(Collectors.joining(", "));
 
             Map<LocationCategoryKey, List<SuggestionRestaurant>> allSuggestions =
-                geminiClient.generateRestaurantsBatch(locationsToCollect, FOOD_CATEGORIES, restaurantNames, RESTAURANTS_PER_REQUEST);
+                    geminiClient.generateRestaurantsBatch(locationsToCollect, FOOD_CATEGORIES, restaurantNames, RESTAURANTS_PER_REQUEST);
 
             AtomicInteger totalProcessed = new AtomicInteger(0);
             AtomicInteger totalSuccess = new AtomicInteger(0);
@@ -160,7 +160,7 @@ public class RestaurantCollectionProcessor {
             }
 
             log.info("Batch completed: {} saved, {} success, {} failed",
-                totalProcessed.get(), totalSuccess.get(), totalFailed.get());
+                    totalProcessed.get(), totalSuccess.get(), totalFailed.get());
 
         } catch (Exception e) {
             log.error("Batch collection failed", e);
@@ -186,10 +186,10 @@ public class RestaurantCollectionProcessor {
             if (currentCount < limit) {
                 locationsToCollect.add(region.getName());
                 log.info("Region {} needs collection: {}/{} restaurants",
-                    region.getName(), currentCount, limit);
+                        region.getName(), currentCount, limit);
             } else {
                 log.info("Region {} reached limit: {}/{} restaurants (skipping)",
-                    region.getName(), currentCount, limit);
+                        region.getName(), currentCount, limit);
             }
         }
 
@@ -210,7 +210,7 @@ public class RestaurantCollectionProcessor {
     @Deprecated
     public int collectRestaurantsForLocation(String location, String category) {
         List<SuggestionRestaurant> suggestions = geminiClient.generateRestaurants(
-            location, category, RESTAURANTS_PER_REQUEST
+                location, category, RESTAURANTS_PER_REQUEST
         );
 
         return processRestaurantsForLocation(location, category, suggestions);
@@ -223,9 +223,9 @@ public class RestaurantCollectionProcessor {
      * Kakao API 호출은 Semaphore({@value KAKAO_COLLECTION_CONCURRENT_PERMITS} permits)로 동시성을 제어합니다.</p>
      */
     public int processRestaurantsForLocation(
-        String location,
-        String category,
-        List<SuggestionRestaurant> suggestions
+            String location,
+            String category,
+            List<SuggestionRestaurant> suggestions
     ) {
         Region region = getRegionFromLocationName(location);
         RestaurantValidator.ValidationContext validationContext =
@@ -395,6 +395,7 @@ public class RestaurantCollectionProcessor {
         enrichedData.apiCategoryName3 = detail.apiCategoryName3();
         enrichedData.apiLargeCategory = detail.apiLargeCategory();
         enrichedData.apiMediumCategory = detail.apiMediumCategory();
+        enrichedData.offDays = detail.offDays();
 
         if (!hasText(enrichedData.aiMateSummaryTitle)) {
             log.info("Skipping restaurant due to missing ai_mate data: {}", suggestion.name());

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionWriteService.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionWriteService.java
@@ -70,7 +70,8 @@ public class RestaurantCollectionWriteService {
                     enrichedData.priceLevel(),
                     enrichedData.aiMateSummaryTitle(),
                     enrichedData.aiMateSummaryContents(),
-                    enrichedData.timeSlot()
+                    enrichedData.timeSlot(),
+                    enrichedData.offDays()
             );
 
             restaurantRepository.save(createRestaurant);

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantEnrichedData.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantEnrichedData.java
@@ -4,6 +4,7 @@ import com.yogieat.category.domain.value.LargeCategory;
 import com.yogieat.common.GeoJson;
 import com.yogieat.gathering.domain.value.TimeSlot;
 import com.yogieat.restaurant.domain.SuggestionRestaurant;
+import java.time.LocalDate;
 import java.util.List;
 
 final class RestaurantEnrichedData {
@@ -27,6 +28,7 @@ final class RestaurantEnrichedData {
     String apiCategoryName3;
     LargeCategory apiLargeCategory;
     String apiMediumCategory;
+    List<LocalDate> offDays;
     boolean skip;
 
     private RestaurantEnrichedData() {
@@ -118,6 +120,10 @@ final class RestaurantEnrichedData {
 
     String apiMediumCategory() {
         return skip ? null : apiMediumCategory;
+    }
+
+    List<LocalDate> offDays() {
+        return skip ? null : offDays;
     }
 
     boolean isSkipped() {

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantRepository.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantRepository.java
@@ -9,6 +9,7 @@ import com.yogieat.restaurant.result.RestaurantAdminResult;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncPatch;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncPatchCommand;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncTarget;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +31,17 @@ public interface RestaurantRepository {
             TimeSlot gatheringTimeSlot,
             Collection<Long> excludedRestaurantIds
     ) {
-        return findRecommendationCandidates(region, categoryIds, gatheringTimeSlot);
+        return findRecommendationCandidates(region, categoryIds, gatheringTimeSlot, excludedRestaurantIds, null);
+    }
+
+    default List<Restaurant> findRecommendationCandidates(
+            Region region,
+            Collection<Long> categoryIds,
+            TimeSlot gatheringTimeSlot,
+            Collection<Long> excludedRestaurantIds,
+            LocalDate scheduledDate
+    ) {
+        return findRecommendationCandidates(region, categoryIds, gatheringTimeSlot, excludedRestaurantIds);
     }
     Optional<Restaurant> findById(Long id);
     List<Restaurant> findByIds(List<Long> ids);

--- a/apps/domain/src/main/java/com/yogieat/restaurant/sync/domain/RestaurantSyncPatch.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/sync/domain/RestaurantSyncPatch.java
@@ -19,6 +19,7 @@ public record RestaurantSyncPatch(
         String aiMateSummaryTitle,
         String aiMateSummaryContents,
         TimeSlot timeSlot,
-        Long categoryId
+        Long categoryId,
+        String offDays
 ) {
 }

--- a/apps/domain/src/main/java/com/yogieat/restaurant/sync/domain/RestaurantSyncPatchCommand.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/sync/domain/RestaurantSyncPatchCommand.java
@@ -20,7 +20,8 @@ public record RestaurantSyncPatchCommand(
         String aiMateSummaryTitle,
         String aiMateSummaryContents,
         TimeSlot timeSlot,
-        Long categoryId
+        Long categoryId,
+        String offDays
 ) {
     public static RestaurantSyncPatchCommand of(Long restaurantId, RestaurantSyncPatch patch) {
         Double longitude = null;
@@ -51,7 +52,8 @@ public record RestaurantSyncPatchCommand(
                 patch.aiMateSummaryTitle(),
                 patch.aiMateSummaryContents(),
                 patch.timeSlot(),
-                patch.categoryId()
+                patch.categoryId(),
+                patch.offDays()
         );
     }
 }

--- a/apps/domain/src/main/java/com/yogieat/restaurant/sync/service/RestaurantSyncService.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/sync/service/RestaurantSyncService.java
@@ -20,6 +20,7 @@ import com.yogieat.restaurant.sync.domain.RestaurantSyncPatch;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncPatchCommand;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncResult;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncTarget;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -133,11 +134,11 @@ public class RestaurantSyncService {
         Semaphore syncTargetSemaphore = new Semaphore(effectiveParallelism);
 
         List<CompletableFuture<SyncExecution>> futures = ids.stream()
-                    .map(id -> CompletableFuture.supplyAsync(
-                            () -> syncTargetWithParallelismLimit(syncTargetSemaphore, id, targetMap.get(id)),
-                            executor
-                    ))
-                    .toList();
+                .map(id -> CompletableFuture.supplyAsync(
+                        () -> syncTargetWithParallelismLimit(syncTargetSemaphore, id, targetMap.get(id)),
+                        executor
+                ))
+                .toList();
 
         List<SyncExecution> executions = futures.stream()
                 .map(CompletableFuture::join)
@@ -492,6 +493,7 @@ public class RestaurantSyncService {
         String aiMateSummaryTitle = detail != null ? detail.aiMateSummaryTitle() : null;
         String aiMateSummaryContents = detail != null ? toJson(detail.aiMateSummaryContents()) : null;
         Long categoryId = resolveCategoryId(detail);
+        String offDays = detail != null ? offDaysToJson(detail.offDays()) : null;
 
         return new RestaurantSyncPatch(
                 externalId,
@@ -509,7 +511,8 @@ public class RestaurantSyncService {
                 aiMateSummaryTitle,
                 aiMateSummaryContents,
                 detail != null ? detail.timeSlot() : null,
-                categoryId
+                categoryId,
+                offDays
         );
     }
 
@@ -571,6 +574,13 @@ public class RestaurantSyncService {
         } catch (JsonProcessingException e) {
             return null;
         }
+    }
+
+    private String offDaysToJson(List<LocalDate> offDays) {
+        if (offDays == null || offDays.isEmpty()) {
+            return null;
+        }
+        return toJson(offDays.stream().map(LocalDate::toString).toList());
     }
 
     private String normalizeMapUrl(String mapUrl) {

--- a/apps/domain/src/main/java/com/yogieat/restaurant/sync/service/RestaurantSyncService.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/sync/service/RestaurantSyncService.java
@@ -577,8 +577,11 @@ public class RestaurantSyncService {
     }
 
     private String offDaysToJson(List<LocalDate> offDays) {
-        if (offDays == null || offDays.isEmpty()) {
+        if (offDays == null) {
             return null;
+        }
+        if (offDays.isEmpty()) {
+            return "[]";
         }
         return toJson(offDays.stream().map(LocalDate::toString).toList());
     }

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
@@ -146,6 +146,7 @@ class RecommendResultFacadeTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
@@ -630,6 +630,7 @@ class RecommendationProcessorTest {
                 null,
                 TimeSlot.BOTH,
                 null,
+                null,
                 null
         );
     }

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
@@ -126,7 +126,7 @@ class RecommendationProcessorTest {
         when(recommendResultRepository.findByGatheringId(gatheringId)).thenReturn(List.of());
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 
@@ -173,7 +173,7 @@ class RecommendationProcessorTest {
         when(recommendResultRepository.findByGatheringId(gatheringId)).thenReturn(List.of());
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 
@@ -202,7 +202,7 @@ class RecommendationProcessorTest {
         when(gatheringRepository.findById(11L)).thenReturn(Optional.empty());
         when(gatheringRepository.findById(12L)).thenReturn(Optional.empty());
         when(gatheringRepository.findById(13L)).thenReturn(Optional.empty());
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 
@@ -273,7 +273,7 @@ class RecommendationProcessorTest {
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.of(gathering));
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
         when(categoryService.findAll()).thenReturn(categories);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any())).thenAnswer(invocation -> {
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any())).thenAnswer(invocation -> {
             Collection<Long> categoryIds = invocation.getArgument(1);
             capturedCandidateCategoryIds = List.copyOf(categoryIds);
             capturedCandidateTimeSlot = invocation.getArgument(2, TimeSlot.class);
@@ -329,7 +329,8 @@ class RecommendationProcessorTest {
                 eq(region),
                 anyCollection(),
                 eq(TimeSlot.DINNER),
-                eq(excludedRestaurantIds)
+                eq(excludedRestaurantIds),
+                any()
         )).thenAnswer(invocation -> {
             Collection<Long> categoryIds = invocation.getArgument(1);
             Collection<Long> excludedIds = invocation.getArgument(3);
@@ -390,7 +391,7 @@ class RecommendationProcessorTest {
         when(recommendResultRepository.findByGatheringId(gatheringId)).thenReturn(List.of());
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 
@@ -435,7 +436,7 @@ class RecommendationProcessorTest {
         when(recommendResultRepository.findByGatheringId(gatheringId)).thenReturn(List.of());
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 
@@ -475,7 +476,7 @@ class RecommendationProcessorTest {
         when(recommendResultRepository.findByGatheringId(gatheringId)).thenReturn(List.of());
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 
@@ -513,7 +514,7 @@ class RecommendationProcessorTest {
         when(recommendResultRepository.findByGatheringId(gatheringId)).thenReturn(List.of());
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 
@@ -551,7 +552,7 @@ class RecommendationProcessorTest {
         when(recommendResultRepository.findByGatheringId(gatheringId)).thenReturn(List.of());
         when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
         when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
-        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any()))
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
                 .thenReturn(restaurants);
         when(categoryService.findAll()).thenReturn(categories);
 

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/strategy/CategoryQuotaSelectionStrategyTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/strategy/CategoryQuotaSelectionStrategyTest.java
@@ -104,6 +104,7 @@ class CategoryQuotaSelectionStrategyTest {
                 null,
                 TimeSlot.BOTH,
                 null,
+                null,
                 null
         );
 

--- a/apps/domain/src/test/java/com/yogieat/restaurant/fixture/RestaurantFixture.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/fixture/RestaurantFixture.java
@@ -34,6 +34,7 @@ public final class RestaurantFixture {
                 List.of("before"),
                 TimeSlot.LUNCH,
                 null,
+                null,
                 null
         );
     }
@@ -61,7 +62,8 @@ public final class RestaurantFixture {
                 List.of("summary"),
                 TimeSlot.BOTH,
                 source.createdAt(),
-                source.updatedAt()
+                source.updatedAt(),
+                null
         );
     }
 

--- a/apps/domain/src/test/java/com/yogieat/restaurant/service/RestaurantValidatorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/service/RestaurantValidatorTest.java
@@ -120,6 +120,7 @@ class RestaurantValidatorTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }

--- a/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncJobServiceTest.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncJobServiceTest.java
@@ -87,6 +87,7 @@ class RestaurantSyncJobServiceTest {
                 null,
                 null,
                 null,
+                null,
                 null
         )));
         when(syncJobRepository.existsByTargetRestaurantIdAndStatus(1L, RestaurantSyncJobStatus.RUNNING)).thenReturn(false);
@@ -158,6 +159,7 @@ class RestaurantSyncJobServiceTest {
                 "name",
                 "address",
                 4.0,
+                null,
                 null,
                 null,
                 null,

--- a/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncServiceTest.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncServiceTest.java
@@ -241,7 +241,8 @@ class RestaurantSyncServiceTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                List.of()
         );
     }
 
@@ -267,7 +268,8 @@ class RestaurantSyncServiceTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                List.of()
         );
     }
 
@@ -293,7 +295,8 @@ class RestaurantSyncServiceTest {
                 name2,
                 name3,
                 null,
-                null
+                null,
+                List.of()
         );
     }
 }

--- a/external/kakao/src/main/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParser.java
+++ b/external/kakao/src/main/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParser.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.yogieat.category.domain.value.LargeCategory;
 import com.yogieat.external.kakao.result.KakaoPlaceDetailData;
 import com.yogieat.gathering.domain.value.TimeSlot;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -74,6 +75,9 @@ public class KakaoPlaceDetailParser {
             LargeCategory apiLargeCategory = extractApiLargeCategory(apiCategoryName2);
             String apiMediumCategory = extractApiMediumCategory(apiCategoryName3, apiLargeCategory);
 
+            // 휴무일 추출
+            List<LocalDate> offDays = extractOffDates(panel);
+
             log.debug("Successfully parsed place: placeId={}, rating={}, photos={}, review={}, reviewCount={}, blogReviewCount={}, timeSlot={}, apiLargeCategory={}, apiMediumCategory={}",
                     confirmId, rating, photoUrls.size(), representativeReview != null, reviewCount, blogReviewCount, timeSlot, apiLargeCategory, apiMediumCategory);
 
@@ -98,7 +102,8 @@ public class KakaoPlaceDetailParser {
                     apiCategoryName2,
                     apiCategoryName3,
                     apiLargeCategory,
-                    apiMediumCategory
+                    apiMediumCategory,
+                    offDays
             );
         } catch (Exception e) {
             log.error("Failed to parse panel3 response for placeId: {}", requestedPlaceId, e);
@@ -668,6 +673,74 @@ public class KakaoPlaceDetailParser {
             return TimeSlot.DINNER;
         }
         return TimeSlot.BOTH;
+    }
+
+    private List<LocalDate> extractOffDates(JsonNode panel) {
+        JsonNode openHours = panel.path("open_hours");
+        if (openHours.isMissingNode() || openHours.isNull()) {
+            return List.of();
+        }
+
+        JsonNode weekPeriods = openHours.path("week_from_today").path("week_periods");
+        if (!weekPeriods.isArray() || weekPeriods.isEmpty()) {
+            return List.of();
+        }
+
+        LocalDate today = LocalDate.now();
+        int currentYear = today.getYear();
+        int currentMonth = today.getMonthValue();
+
+        Set<LocalDate> offDates = new HashSet<>();
+        for (JsonNode period : weekPeriods) {
+            JsonNode days = period.path("days");
+            if (!days.isArray()) {
+                continue;
+            }
+            for (JsonNode day : days) {
+                if (!isOffDay(day)) {
+                    continue;
+                }
+                String dayDesc = extractText(day, "day_of_the_week_desc");
+                if (dayDesc == null) {
+                    continue;
+                }
+                LocalDate date = parseOffDayDate(dayDesc, currentYear, currentMonth);
+                if (date != null) {
+                    offDates.add(date);
+                }
+            }
+        }
+        return new ArrayList<>(offDates);
+    }
+
+    private boolean isOffDay(JsonNode day) {
+        JsonNode offDaysDesc = day.get("off_days_desc");
+        if (offDaysDesc == null || offDaysDesc.isNull() || offDaysDesc.isMissingNode()) {
+            return false;
+        }
+        return "휴무일".equals(offDaysDesc.asText());
+    }
+
+    private LocalDate parseOffDayDate(String dayDesc, int year, int currentMonth) {
+        try {
+            int start = dayDesc.indexOf('(');
+            int end = dayDesc.indexOf(')');
+            if (start < 0 || end <= start) {
+                return null;
+            }
+            String[] parts = dayDesc.substring(start + 1, end).split("/");
+            if (parts.length != 2) {
+                return null;
+            }
+            int month = Integer.parseInt(parts[0].trim());
+            int day = Integer.parseInt(parts[1].trim());
+            // 12월 말 → 1월 초 경계 처리
+            int adjustedYear = (currentMonth == 12 && month == 1) ? year + 1 : year;
+            return LocalDate.of(adjustedYear, month, day);
+        } catch (Exception e) {
+            log.debug("Failed to parse off day date: {}", dayDesc);
+            return null;
+        }
     }
 
     /**

--- a/external/kakao/src/main/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParser.java
+++ b/external/kakao/src/main/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParser.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.yogieat.category.domain.value.LargeCategory;
 import com.yogieat.external.kakao.result.KakaoPlaceDetailData;
 import com.yogieat.gathering.domain.value.TimeSlot;
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -17,6 +19,17 @@ import org.springframework.stereotype.Component;
 public class KakaoPlaceDetailParser {
 
     private static final int MAX_PHOTOS = 15;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final Clock clock;
+
+    public KakaoPlaceDetailParser() {
+        this(Clock.system(KST));
+    }
+
+    KakaoPlaceDetailParser(Clock clock) {
+        this.clock = clock;
+    }
 
     public KakaoPlaceDetailData parse(JsonNode panel, String requestedPlaceId) {
         try {
@@ -686,7 +699,7 @@ public class KakaoPlaceDetailParser {
             return List.of();
         }
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(clock);
         int currentYear = today.getYear();
         int currentMonth = today.getMonthValue();
 

--- a/external/kakao/src/test/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParserTest.java
+++ b/external/kakao/src/test/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParserTest.java
@@ -5,20 +5,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yogieat.external.kakao.result.KakaoPlaceDetailData;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class KakaoPlaceDetailParserTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private final KakaoPlaceDetailParser parser = new KakaoPlaceDetailParser();
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    // 테스트 기준 날짜: 2026-04-21 (KST)
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-04-20T15:00:00Z"), KST); // UTC 15:00 = KST 00:00 (4/21)
+    private final KakaoPlaceDetailParser parser = new KakaoPlaceDetailParser(FIXED_CLOCK);
     private static final String PLACE_ID = "16053234";
+    private static final int YEAR = 2026;
 
     @Test
     @DisplayName("off_days_desc가 '휴무일'인 날짜만 off_days로 수집한다")
     void parse_collectsOffDays() throws Exception {
-        int year = LocalDate.now().getYear();
+        int year = YEAR;
         JsonNode panel = panel("""
                 {
                   "summary": {
@@ -117,7 +125,7 @@ class KakaoPlaceDetailParserTest {
     @Test
     @DisplayName("동일한 날짜가 여러 period에 중복 등장해도 한 번만 수집한다")
     void parse_deduplicatesOffDays() throws Exception {
-        int year = LocalDate.now().getYear();
+        int year = YEAR;
         JsonNode panel = panel("""
                 {
                   "summary": {

--- a/external/kakao/src/test/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParserTest.java
+++ b/external/kakao/src/test/java/com/yogieat/kakao/kakao/map/KakaoPlaceDetailParserTest.java
@@ -1,0 +1,177 @@
+package com.yogieat.kakao.kakao.map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yogieat.external.kakao.result.KakaoPlaceDetailData;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class KakaoPlaceDetailParserTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private final KakaoPlaceDetailParser parser = new KakaoPlaceDetailParser();
+    private static final String PLACE_ID = "16053234";
+
+    @Test
+    @DisplayName("off_days_desc가 '휴무일'인 날짜만 off_days로 수집한다")
+    void parse_collectsOffDays() throws Exception {
+        int year = LocalDate.now().getYear();
+        JsonNode panel = panel("""
+                {
+                  "summary": {
+                    "category": {"name1": "음식점", "name2": "한식", "name3": "육류,고기"},
+                    "name": "테스트식당",
+                    "confirm_id": "16053234",
+                    "address": {"road": "서울 어딘가"},
+                    "point": {"lat": 37.5, "lon": 127.0}
+                  },
+                  "kakaomap_review": {"score_set": {"average_score": 4.0, "review_count": 10}},
+                  "open_hours": {
+                    "week_from_today": {
+                      "week_periods": [
+                        {"days": [
+                          {"day_of_the_week_desc": "화(4/21)", "on_days": {"start_end_time_desc": "15:00 ~ 22:00"}},
+                          {"day_of_the_week_desc": "수(4/22)", "on_days": {"start_end_time_desc": "15:00 ~ 22:00"}}
+                        ]},
+                        {"days": [
+                          {"day_of_the_week_desc": "일(4/26)", "off_days_desc": "휴무일"}
+                        ]},
+                        {"days": [
+                          {"day_of_the_week_desc": "월(4/27)", "on_days": {"start_end_time_desc": "15:00 ~ 22:00"}}
+                        ]}
+                      ]
+                    }
+                  }
+                }
+                """);
+
+        KakaoPlaceDetailData result = parser.parse(panel, PLACE_ID);
+
+        assertThat(result.offDays()).containsExactly(LocalDate.of(year, 4, 26));
+    }
+
+    @Test
+    @DisplayName("on_days만 있고 off_days_desc가 없으면 off_days는 빈 리스트다")
+    void parse_emptyOffDaysWhenAllOpen() throws Exception {
+        JsonNode panel = panel("""
+                {
+                  "summary": {
+                    "category": {"name1": "음식점", "name2": "한식", "name3": "육류,고기"},
+                    "name": "테스트식당",
+                    "confirm_id": "16053234",
+                    "address": {"road": "서울 어딘가"},
+                    "point": {"lat": 37.5, "lon": 127.0}
+                  },
+                  "kakaomap_review": {"score_set": {"average_score": 4.0, "review_count": 10}},
+                  "open_hours": {
+                    "week_from_today": {
+                      "week_periods": [
+                        {"days": [
+                          {"day_of_the_week_desc": "화(4/21)", "on_days": {"start_end_time_desc": "15:00 ~ 22:00"}},
+                          {"day_of_the_week_desc": "수(4/22)", "on_days": {"start_end_time_desc": "15:00 ~ 22:00"}}
+                        ]}
+                      ]
+                    }
+                  }
+                }
+                """);
+
+        KakaoPlaceDetailData result = parser.parse(panel, PLACE_ID);
+
+        assertThat(result.offDays()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("off_days_desc 값이 '휴무일'이 아니면 off_days에 포함하지 않는다")
+    void parse_ignoresNonStandardOffDaysDesc() throws Exception {
+        JsonNode panel = panel("""
+                {
+                  "summary": {
+                    "category": {"name1": "음식점", "name2": "한식", "name3": "육류,고기"},
+                    "name": "테스트식당",
+                    "confirm_id": "16053234",
+                    "address": {"road": "서울 어딘가"},
+                    "point": {"lat": 37.5, "lon": 127.0}
+                  },
+                  "kakaomap_review": {"score_set": {"average_score": 4.0, "review_count": 10}},
+                  "open_hours": {
+                    "week_from_today": {
+                      "week_periods": [
+                        {"days": [
+                          {"day_of_the_week_desc": "일(4/26)", "off_days_desc": "임시휴무"}
+                        ]}
+                      ]
+                    }
+                  }
+                }
+                """);
+
+        KakaoPlaceDetailData result = parser.parse(panel, PLACE_ID);
+
+        assertThat(result.offDays()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("동일한 날짜가 여러 period에 중복 등장해도 한 번만 수집한다")
+    void parse_deduplicatesOffDays() throws Exception {
+        int year = LocalDate.now().getYear();
+        JsonNode panel = panel("""
+                {
+                  "summary": {
+                    "category": {"name1": "음식점", "name2": "한식", "name3": "육류,고기"},
+                    "name": "테스트식당",
+                    "confirm_id": "16053234",
+                    "address": {"road": "서울 어딘가"},
+                    "point": {"lat": 37.5, "lon": 127.0}
+                  },
+                  "kakaomap_review": {"score_set": {"average_score": 4.0, "review_count": 10}},
+                  "open_hours": {
+                    "week_from_today": {
+                      "week_periods": [
+                        {"days": [
+                          {"day_of_the_week_desc": "일(4/26)", "off_days_desc": "휴무일"}
+                        ]},
+                        {"days": [
+                          {"day_of_the_week_desc": "일(4/26)", "off_days_desc": "휴무일"}
+                        ]}
+                      ]
+                    }
+                  }
+                }
+                """);
+
+        KakaoPlaceDetailData result = parser.parse(panel, PLACE_ID);
+
+        assertThat(result.offDays())
+                .hasSize(1)
+                .containsExactly(LocalDate.of(year, 4, 26));
+    }
+
+    @Test
+    @DisplayName("open_hours가 없으면 off_days는 빈 리스트다")
+    void parse_emptyOffDaysWhenNoOpenHours() throws Exception {
+        JsonNode panel = panel("""
+                {
+                  "summary": {
+                    "category": {"name1": "음식점", "name2": "한식", "name3": "육류,고기"},
+                    "name": "테스트식당",
+                    "confirm_id": "16053234",
+                    "address": {"road": "서울 어딘가"},
+                    "point": {"lat": 37.5, "lon": 127.0}
+                  },
+                  "kakaomap_review": {"score_set": {"average_score": 4.0, "review_count": 10}}
+                }
+                """);
+
+        KakaoPlaceDetailData result = parser.parse(panel, PLACE_ID);
+
+        assertThat(result.offDays()).isEmpty();
+    }
+
+    private static JsonNode panel(String json) throws Exception {
+        return OBJECT_MAPPER.readTree(json);
+    }
+}

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
@@ -96,7 +96,7 @@ public class RestaurantCoreRepository implements RestaurantRepository {
             Collection<Long> categoryIds,
             TimeSlot gatheringTimeSlot
     ) {
-        return findRecommendationCandidates(region, categoryIds, gatheringTimeSlot, List.of());
+        return findRecommendationCandidates(region, categoryIds, gatheringTimeSlot, List.of(), null);
     }
 
     @Override
@@ -105,6 +105,17 @@ public class RestaurantCoreRepository implements RestaurantRepository {
             Collection<Long> categoryIds,
             TimeSlot gatheringTimeSlot,
             Collection<Long> excludedRestaurantIds
+    ) {
+        return findRecommendationCandidates(region, categoryIds, gatheringTimeSlot, excludedRestaurantIds, null);
+    }
+
+    @Override
+    public List<Restaurant> findRecommendationCandidates(
+            Region region,
+            Collection<Long> categoryIds,
+            TimeSlot gatheringTimeSlot,
+            Collection<Long> excludedRestaurantIds,
+            LocalDate scheduledDate
     ) {
         if (categoryIds == null || categoryIds.isEmpty()) {
             return List.of();
@@ -132,7 +143,8 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                         regionCondition(region),
                         restaurantEntity.categoryId.in(categoryIds),
                         recommendationTimeSlotCondition(gatheringTimeSlot),
-                        excludedRestaurantIdsCondition(excludedRestaurantIds)
+                        excludedRestaurantIdsCondition(excludedRestaurantIds),
+                        offDaysNotContainsCondition(scheduledDate)
                 )
                 .fetch();
         Map<Long, Region> regionMap = resolveRegionMap(
@@ -398,6 +410,16 @@ public class RestaurantCoreRepository implements RestaurantRepository {
         }
 
         return restaurantEntity.id.notIn(excludedRestaurantIds);
+    }
+
+    private BooleanExpression offDaysNotContainsCondition(LocalDate scheduledDate) {
+        if (scheduledDate == null) {
+            return null;
+        }
+        // off_days는 ["YYYY-MM-DD", ...] 형식의 JSON 텍스트이므로 quoted 날짜 문자열 포함 여부로 판단
+        String datePattern = "%\"" + scheduledDate + "\"%";
+        return restaurantEntity.offDays.isNull()
+                .or(restaurantEntity.offDays.notLike(datePattern));
     }
 
     private Restaurant toRecommendationCandidate(Tuple tuple, Map<Long, Region> regionMap) {

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
@@ -26,6 +26,7 @@ import com.yogieat.restaurant.sync.domain.RestaurantSyncPatch;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncPatchCommand;
 import com.yogieat.restaurant.sync.domain.RestaurantSyncTarget;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -122,7 +123,8 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                         restaurantEntity.aiMateSummaryContents,
                         restaurantEntity.timeSlot,
                         restaurantEntity.createdAt,
-                        restaurantEntity.updatedAt
+                        restaurantEntity.updatedAt,
+                        restaurantEntity.offDays
                 )
                 .from(restaurantEntity)
                 .where(
@@ -425,7 +427,8 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                 parseAiMateSummaryContents(tuple.get(restaurantEntity.aiMateSummaryContents)),
                 tuple.get(restaurantEntity.timeSlot),
                 tuple.get(restaurantEntity.createdAt),
-                tuple.get(restaurantEntity.updatedAt)
+                tuple.get(restaurantEntity.updatedAt),
+                parseOffDays(tuple.get(restaurantEntity.offDays))
         );
     }
 
@@ -442,6 +445,18 @@ public class RestaurantCoreRepository implements RestaurantRepository {
         }
         try {
             return OBJECT_MAPPER.readValue(json, STRING_LIST_TYPE);
+        } catch (Exception ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    private List<LocalDate> parseOffDays(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            List<String> dateStrings = OBJECT_MAPPER.readValue(json, STRING_LIST_TYPE);
+            return dateStrings.stream().map(LocalDate::parse).toList();
         } catch (Exception ignored) {
             return Collections.emptyList();
         }

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
@@ -577,6 +577,8 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                     ai_mate_summary_contents = coalesce(:aiMateSummaryContents, ai_mate_summary_contents),
                     time_slot = coalesce(:timeSlot, time_slot),
                     category_id = coalesce(:categoryId, category_id),
+                    off_days = coalesce(:offDays, off_days),
+                    off_days_updated_at = case when :offDays is not null then now() else off_days_updated_at end,
                     updated_at = now()
                 where id = :restaurantId
                   and deleted_at is null
@@ -605,6 +607,7 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                         .addValue("aiMateSummaryContents", command.aiMateSummaryContents())
                         .addValue("timeSlot", command.timeSlot() != null ? command.timeSlot().name() : null)
                         .addValue("categoryId", command.categoryId())
+                        .addValue("offDays", command.offDays())
                 )
                 .toArray(MapSqlParameterSource[]::new);
 

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
@@ -17,6 +17,8 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import lombok.AccessLevel;
@@ -33,39 +35,39 @@ import org.locationtech.jts.geom.PrecisionModel;
 @Getter
 @Entity
 @Table(
-    name = "t_restaurant",
-    indexes = {
-        @Index(
-            name = "idx_restaurant_name_address",
-            columnList = "name, address",
-            unique = false
-        ),
-        @Index(
-            name = "idx_restaurant_category_id",
-            columnList = "category_id",
-            unique = false
-        ),
-        @Index(
-            name = "idx_restaurant_deleted_at",
-            columnList = "deleted_at",
-            unique = false
-        ),
-        @Index(
-            name = "idx_restaurant_deleted_at_id",
-            columnList = "deleted_at, id",
-            unique = false
-        ),
-        @Index(
-            name = "idx_restaurant_region_id",
-            columnList = "region_id",
-            unique = false
-        ),
-        @Index(
-            name = "idx_restaurant_region_id_deleted_at",
-            columnList = "region_id, deleted_at",
-            unique = false
-        )
-    }
+        name = "t_restaurant",
+        indexes = {
+                @Index(
+                        name = "idx_restaurant_name_address",
+                        columnList = "name, address",
+                        unique = false
+                ),
+                @Index(
+                        name = "idx_restaurant_category_id",
+                        columnList = "category_id",
+                        unique = false
+                ),
+                @Index(
+                        name = "idx_restaurant_deleted_at",
+                        columnList = "deleted_at",
+                        unique = false
+                ),
+                @Index(
+                        name = "idx_restaurant_deleted_at_id",
+                        columnList = "deleted_at, id",
+                        unique = false
+                ),
+                @Index(
+                        name = "idx_restaurant_region_id",
+                        columnList = "region_id",
+                        unique = false
+                ),
+                @Index(
+                        name = "idx_restaurant_region_id_deleted_at",
+                        columnList = "region_id, deleted_at",
+                        unique = false
+                )
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RestaurantEntity extends BaseEntity {
@@ -108,6 +110,13 @@ public class RestaurantEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TimeSlot timeSlot;
 
+    // 휴무일
+    @Column(name = "off_days", columnDefinition = "TEXT")
+    private String offDays;  // JSON 문자열
+
+    @Column(name = "off_days_updated_at")
+    private LocalDateTime offDaysUpdatedAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     private RestaurantEntity(
             String externalId,
@@ -130,7 +139,9 @@ public class RestaurantEntity extends BaseEntity {
             String aiMateSummaryTitle,
             String aiMateSummaryContents,
             // 추천 시간대
-            TimeSlot timeSlot) {
+            TimeSlot timeSlot,
+            // 휴무일
+            String offDays) {
         this.externalId = externalId;
         this.name = name;
         this.address = address;
@@ -150,6 +161,7 @@ public class RestaurantEntity extends BaseEntity {
         this.aiMateSummaryTitle = aiMateSummaryTitle;
         this.aiMateSummaryContents = aiMateSummaryContents;
         this.timeSlot = timeSlot;
+        this.offDays = offDays;
     }
 
     /**
@@ -189,6 +201,8 @@ public class RestaurantEntity extends BaseEntity {
                 .aiMateSummaryContents(createRestaurant.aiMateSummaryContents())
                 // 추천 시간대
                 .timeSlot(createRestaurant.timeSlot())
+                // 휴무일
+                .offDays(createRestaurant.offDays())
                 .build();
     }
 
@@ -206,8 +220,8 @@ public class RestaurantEntity extends BaseEntity {
                 entity.getDescription(),
                 region,
                 entity.location != null
-                    ? new GeoJson.Point(List.of(entity.location.getX(), entity.location.getY()))
-                    : null,
+                        ? new GeoJson.Point(List.of(entity.location.getX(), entity.location.getY()))
+                        : null,
                 // 추천 근거 데이터
                 entity.getReviewCount(),
                 entity.getBlogReviewCount(),
@@ -220,7 +234,9 @@ public class RestaurantEntity extends BaseEntity {
                 entity.getTimeSlot(),
                 // 추천 알고리즘용 시간 데이터
                 entity.getCreatedAt(),
-                entity.getUpdatedAt()
+                entity.getUpdatedAt(),
+                // 휴무일
+                parseOffDays(entity.getOffDays())
         );
     }
 
@@ -237,6 +253,19 @@ public class RestaurantEntity extends BaseEntity {
             return OBJECT_MAPPER.readValue(json, new TypeReference<List<String>>() {});
         } catch (Exception e) {
             log.warn("Failed to parse aiMateSummaryContents: {}", json);
+            return Collections.emptyList();
+        }
+    }
+
+    private static List<LocalDate> parseOffDays(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            List<String> dateStrings = OBJECT_MAPPER.readValue(json, new TypeReference<List<String>>() {});
+            return dateStrings.stream().map(LocalDate::parse).toList();
+        } catch (Exception e) {
+            log.warn("Failed to parse offDays: {}", json);
             return Collections.emptyList();
         }
     }
@@ -289,6 +318,10 @@ public class RestaurantEntity extends BaseEntity {
         }
         if (patch.categoryId() != null) {
             this.categoryId = patch.categoryId();
+        }
+        if (patch.offDays() != null) {
+            this.offDays = patch.offDays();
+            this.offDaysUpdatedAt = LocalDateTime.now();
         }
     }
 

--- a/storage/db-core/src/main/resources/db/migration/V2__add_off_days_to_restaurant.sql
+++ b/storage/db-core/src/main/resources/db/migration/V2__add_off_days_to_restaurant.sql
@@ -1,0 +1,3 @@
+ALTER TABLE
+    t_restaurant ADD COLUMN off_days TEXT,
+    ADD COLUMN off_days_updated_at TIMESTAMP;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #153 

## 📌 작업 내용

- 카카오맵 panel3 API(open_hours.week_from_today)에서 이번 주 휴무일 데이터 수집
- `t_restaurant`에 `off_days` (TEXT/JSON), `off_days_updated_at` (TIMESTAMP) 컬럼 추가 (V2 migration)
- `t_restaurant`에`off_days`는 `["YYYY-MM-DD", ...]` 형태로 저장
- 식당 신규 수집 및 주간 동기화(sync job) 시 휴무일 데이터 저장
- 추천 시 모임 날짜(`gathering.scheduledDate()`)가 휴무일인 식당 필터링

## 📝 참고

- 파싱 기준: off_days_desc == "휴무일"인 날짜만 수집, 중복 제거
- off_days = null → 해당 식당의 카카오 API 호출 실패 (미갱신), off_days = "[]" → 이번 주 휴무 없음으로 구분

## 💬 리뷰 요구사항(선택)

-