### PR TITLE
[Chore] jib 배포

### DIFF
--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -2,7 +2,7 @@ name: develop Build And Deploy
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "chore/jib" ]
 
 env:
   DOCKERHUB_USERNAME: yogieat
@@ -44,12 +44,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --no-daemon
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set image tags
         id: image-tags
         run: |
@@ -57,41 +51,14 @@ jobs:
           echo "admin_image=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_ADMIN_IMAGE_NAME }}:${{ github.sha }}" >> $GITHUB_OUTPUT
           echo "batch_image=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_BATCH_IMAGE_NAME }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push API image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          build-args: |
-            JAR_FILE=apps/api/build/libs/*.jar
-          tags: ${{ steps.image-tags.outputs.api_image }}
-          platforms: linux/amd64
-
-      - name: Build and push Admin image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          build-args: |
-            JAR_FILE=apps/admin/build/libs/*.jar
-          tags: ${{ steps.image-tags.outputs.admin_image }}
-          platforms: linux/amd64
-
-      - name: Build and push Batch image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          build-args: |
-            JAR_FILE=batch/sync/build/libs/*.jar
-          tags: ${{ steps.image-tags.outputs.batch_image }}
-          platforms: linux/amd64
+      - name: Build and push images with Jib
+        env:
+          API_IMAGE_FULL_URL: ${{ steps.image-tags.outputs.api_image }}
+          ADMIN_IMAGE_FULL_URL: ${{ steps.image-tags.outputs.admin_image }}
+          BATCH_IMAGE_FULL_URL: ${{ steps.image-tags.outputs.batch_image }}
+          DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: ./gradlew jibPushAll --no-daemon
 
       # 서버로 docker 관련 파일 전송
       - name: Copy docker directory to Server

--- a/.github/workflows/develop_build_deploy.yml
+++ b/.github/workflows/develop_build_deploy.yml
@@ -2,7 +2,7 @@ name: develop Build And Deploy
 
 on:
   push:
-    branches: [ "chore/jib" ]
+    branches: [ "develop" ]
 
 env:
   DOCKERHUB_USERNAME: yogieat

--- a/.github/workflows/production_build_deploy.yml
+++ b/.github/workflows/production_build_deploy.yml
@@ -44,12 +44,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --no-daemon
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set image tags
         id: image-tags
         run: |
@@ -57,41 +51,14 @@ jobs:
           echo "admin_image=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_ADMIN_IMAGE_NAME }}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
           echo "batch_image=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_BATCH_IMAGE_NAME }}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push API image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          build-args: |
-            JAR_FILE=apps/api/build/libs/*.jar
-          tags: ${{ steps.image-tags.outputs.api_image }}
-          platforms: linux/amd64
-
-      - name: Build and push Admin image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          build-args: |
-            JAR_FILE=apps/admin/build/libs/*.jar
-          tags: ${{ steps.image-tags.outputs.admin_image }}
-          platforms: linux/amd64
-
-      - name: Build and push Batch image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          push: true
-          build-args: |
-            JAR_FILE=batch/sync/build/libs/*.jar
-          tags: ${{ steps.image-tags.outputs.batch_image }}
-          platforms: linux/amd64
+      - name: Build and push images with Jib
+        env:
+          API_IMAGE_FULL_URL: ${{ steps.image-tags.outputs.api_image }}
+          ADMIN_IMAGE_FULL_URL: ${{ steps.image-tags.outputs.admin_image }}
+          BATCH_IMAGE_FULL_URL: ${{ steps.image-tags.outputs.batch_image }}
+          DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: ./gradlew jibPushAll --no-daemon
 
       # 서버로 docker 관련 파일 전송
       - name: Copy docker directory to Server

--- a/apps/admin/build.gradle
+++ b/apps/admin/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'com.google.cloud.tools.jib'
+
 dependencies {
     implementation project(":apps:domain")
     implementation project(":storage:db-core")
@@ -22,4 +24,27 @@ tasks.named("bootJar") {
 
 tasks.named("jar") {
     enabled = false
+}
+
+def dockerHubUsername = System.getenv('DOCKERHUB_USERNAME')
+def dockerHubToken = System.getenv('DOCKERHUB_TOKEN')
+
+jib {
+    from {
+        image = 'amazoncorretto:25-alpine-jdk'
+    }
+    to {
+        image = System.getenv('ADMIN_IMAGE_FULL_URL') ?: 'yogieat/yogieat-server-admin:local'
+        if (dockerHubUsername && dockerHubToken) {
+            auth {
+                username = dockerHubUsername
+                password = dockerHubToken
+            }
+        }
+    }
+    containerizingMode = 'exploded'
+    container {
+        mainClass = 'com.yogieat.AdminApplication'
+        environment = [TZ: 'Asia/Seoul']
+    }
 }

--- a/apps/admin/src/main/resources/application.yaml
+++ b/apps/admin/src/main/resources/application.yaml
@@ -16,6 +16,10 @@ spring:
 
 server:
   port: 8081
+  tomcat:
+    threads:
+      max: ${ADMIN_TOMCAT_MAX_THREADS:32}
+      min-spare: ${ADMIN_TOMCAT_MIN_THREADS:4}
 
 jwt:
   secret: ${JWT_SECRET:your-256-bit-secret-key-here-must-be-at-least-32-characters}

--- a/apps/api/build.gradle
+++ b/apps/api/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'com.google.cloud.tools.jib'
+
 dependencies {
     // Internal module dependencies
     implementation project(':apps:domain')
@@ -27,4 +29,27 @@ tasks.named('bootJar') {
 
 tasks.named('jar') {
     enabled = false
+}
+
+def dockerHubUsername = System.getenv('DOCKERHUB_USERNAME')
+def dockerHubToken = System.getenv('DOCKERHUB_TOKEN')
+
+jib {
+    from {
+        image = 'amazoncorretto:25-alpine-jdk'
+    }
+    to {
+        image = System.getenv('API_IMAGE_FULL_URL') ?: 'yogieat/yogieat-server-api:local'
+        if (dockerHubUsername && dockerHubToken) {
+            auth {
+                username = dockerHubUsername
+                password = dockerHubToken
+            }
+        }
+    }
+    containerizingMode = 'exploded'
+    container {
+        mainClass = 'com.yogieat.ServerApplication'
+        environment = [TZ: 'Asia/Seoul']
+    }
 }

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionProcessor.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionProcessor.java
@@ -78,19 +78,19 @@ public class RestaurantCollectionProcessor {
     /**
      * 지역별 맛집 수집 제한
      * GANGNAM, HONGDAE: 100개
-     * 나머지 지역: 50개
+     * 2025.04.22 나머지 지역도 100개 제한으로 통일 (추후 데이터 상황에 따라 조정 가능)
      */
     private static final Map<Region, Integer> REGION_LIMITS = Map.of(
         Region.GANGNAM, 100,
         Region.HONGDAE, 100,
-        Region.GONGDEOK, 50,
-        Region.EULJIRO3GA, 50,
-        Region.SADANG, 50,
-        Region.JONGNO3GA, 50,
-        Region.JAMSIL, 50,
-        Region.SAMGAKJI, 50
+        Region.GONGDEOK, 100,
+        Region.EULJIRO3GA, 100,
+        Region.SADANG, 100,
+        Region.JONGNO3GA, 100,
+        Region.JAMSIL, 100,
+        Region.SAMGAKJI, 100
     );
-    private static final int DEFAULT_REGION_LIMIT = 50;
+    private static final int DEFAULT_REGION_LIMIT = 100;
 
     private final Semaphore kakaoApiSemaphore = new Semaphore(KAKAO_COLLECTION_CONCURRENT_PERMITS);
 

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionProcessor.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionProcessor.java
@@ -77,19 +77,8 @@ public class RestaurantCollectionProcessor {
 
     /**
      * 지역별 맛집 수집 제한
-     * GANGNAM, HONGDAE: 100개
-     * 2025.04.22 나머지 지역도 100개 제한으로 통일 (추후 데이터 상황에 따라 조정 가능)
+     * 모든 지역을 100개 제한으로 통일한다. (추후 데이터 상황에 따라 조정 가능)
      */
-    private static final Map<Region, Integer> REGION_LIMITS = Map.of(
-        Region.GANGNAM, 100,
-        Region.HONGDAE, 100,
-        Region.GONGDEOK, 100,
-        Region.EULJIRO3GA, 100,
-        Region.SADANG, 100,
-        Region.JONGNO3GA, 100,
-        Region.JAMSIL, 100,
-        Region.SAMGAKJI, 100
-    );
     private static final int DEFAULT_REGION_LIMIT = 100;
 
     private final Semaphore kakaoApiSemaphore = new Semaphore(KAKAO_COLLECTION_CONCURRENT_PERMITS);
@@ -181,7 +170,7 @@ public class RestaurantCollectionProcessor {
 
         for (Region region : Region.values()) {
             long currentCount = regionCounts.getOrDefault(region, 0L);
-            int limit = REGION_LIMITS.getOrDefault(region, DEFAULT_REGION_LIMIT);
+            int limit = DEFAULT_REGION_LIMIT;
 
             if (currentCount < limit) {
                 locationsToCollect.add(region.getName());
@@ -198,7 +187,7 @@ public class RestaurantCollectionProcessor {
 
     private boolean isRegionLimitReached(Region region, Map<Region, Long> regionCounts) {
         long currentCount = regionCounts.getOrDefault(region, 0L);
-        int limit = REGION_LIMITS.getOrDefault(region, DEFAULT_REGION_LIMIT);
+        int limit = DEFAULT_REGION_LIMIT;
         return currentCount >= limit;
     }
 

--- a/batch/sync/build.gradle
+++ b/batch/sync/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'com.google.cloud.tools.jib'
+
 dependencies {
     implementation project(':apps:domain')
     implementation project(':storage:db-core')
@@ -15,4 +17,27 @@ tasks.named('bootJar') {
 
 tasks.named('jar') {
     enabled = false
+}
+
+def dockerHubUsername = System.getenv('DOCKERHUB_USERNAME')
+def dockerHubToken = System.getenv('DOCKERHUB_TOKEN')
+
+jib {
+    from {
+        image = 'amazoncorretto:25-alpine-jdk'
+    }
+    to {
+        image = System.getenv('BATCH_IMAGE_FULL_URL') ?: 'yogieat/yogieat-server-batch-sync:local'
+        if (dockerHubUsername && dockerHubToken) {
+            auth {
+                username = dockerHubUsername
+                password = dockerHubToken
+            }
+        }
+    }
+    containerizingMode = 'exploded'
+    container {
+        mainClass = 'com.yogieat.SyncBatchApplication'
+        environment = [TZ: 'Asia/Seoul']
+    }
 }

--- a/batch/sync/src/main/resources/application.yaml
+++ b/batch/sync/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
 sync:
   job:
     chunk-size: 50
-    parallelism: 4
+    parallelism: ${SYNC_JOB_PARALLELISM:4}
     poll-delay-ms: 5000
     stale-running-threshold-minutes: 60
     weekly-cron: "0 0 21 ? * SUN"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version "${springBootVersion}" apply false
     id 'io.spring.dependency-management' version "${springDependencyManagementVersion}" apply false
     id 'com.diffplug.spotless' version "${spotlessVersion}" apply false
+    id 'com.google.cloud.tools.jib' version '3.5.3' apply false
 }
 
 group = projectGroup
@@ -87,7 +88,7 @@ subprojects {
         }
     }
 
-    // Default: disable bootJar for all subprojects (enabled only in apps/api)
+    // Default: disable bootJar for all subprojects (enabled only in application modules)
     tasks.named('bootJar') {
         enabled = false
     }
@@ -116,4 +117,40 @@ allprojects {
     tasks.matching { it.name == 'build' }.configureEach {
         dependsOn rootProject.tasks.installGitHook
     }
+}
+
+def deployableModules = [
+        ':apps:api',
+        ':apps:admin',
+        ':batch:sync'
+]
+
+tasks.register('validateJibPushEnv') {
+    doLast {
+        def requiredEnvNames = [
+                'API_IMAGE_FULL_URL',
+                'ADMIN_IMAGE_FULL_URL',
+                'BATCH_IMAGE_FULL_URL',
+                'DOCKERHUB_USERNAME',
+                'DOCKERHUB_TOKEN'
+        ]
+        def missingEnvNames = requiredEnvNames.findAll { !System.getenv(it) }
+
+        if (!missingEnvNames.isEmpty()) {
+            throw new GradleException("Missing Jib push environment variables: ${missingEnvNames.join(', ')}")
+        }
+    }
+}
+
+tasks.register('jibPushAll') {
+    group = 'container'
+    description = 'Builds and pushes API, Admin, and Batch images with Jib.'
+    dependsOn tasks.named('validateJibPushEnv')
+    dependsOn deployableModules.collect { "${it}:jib" }
+}
+
+tasks.register('jibDockerBuildAll') {
+    group = 'container'
+    description = 'Builds API, Admin, and Batch images into the local Docker daemon with Jib.'
+    dependsOn deployableModules.collect { "${it}:jibDockerBuild" }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
+# Fallback build path when Jib is unavailable.
 FROM amazoncorretto:25-alpine-jdk
 ENV TZ=Asia/Seoul
 ARG JAR_FILE=apps/api/build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-XX:+UseZGC", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -1,44 +1,47 @@
 # Dev 2vCore, 4GB RAM, 50GB Storage
 services:
   yogieat-api:
-    cpus: "0.90"
-    mem_limit: "1440m"
-    mem_reservation: "720m"
+    cpus: "1.00"
+    mem_limit: "1536m"
+    mem_reservation: "768m"
     environment:
-      - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=10
-      - DATASOURCE_DB_CORE_MINIMUM_IDLE=1
-      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=3000
-      - API_TOMCAT_MAX_THREADS=300
-      - API_TOMCAT_MIN_THREADS=35
-      - JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=70.0 -XX:MinRAMPercentage=35.0 -XX:MaxGCPauseMillis=400
+      - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=18
+      - DATASOURCE_DB_CORE_MINIMUM_IDLE=4
+      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=1500
+      - API_TOMCAT_MAX_THREADS=128
+      - API_TOMCAT_MIN_THREADS=16
+      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=65.0 -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication
 
   yogieat-admin:
-    cpus: "0.50"
-    mem_limit: "800m"
-    mem_reservation: "400m"
+    cpus: "0.25"
+    mem_limit: "512m"
+    mem_reservation: "256m"
     environment:
-      - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=5
-      - DATASOURCE_DB_CORE_MINIMUM_IDLE=1
-      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=3000
-      - JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=60.0 -XX:MinRAMPercentage=30.0 -XX:MaxGCPauseMillis=600
+      - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=6
+      - DATASOURCE_DB_CORE_MINIMUM_IDLE=2
+      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=2000
+      - ADMIN_TOMCAT_MAX_THREADS=32
+      - ADMIN_TOMCAT_MIN_THREADS=4
+      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=55.0 -XX:MaxGCPauseMillis=300
 
   yogieat-batch-sync:
     cpus: "0.20"
-    mem_limit: "320m"
-    mem_reservation: "160m"
+    mem_limit: "384m"
+    mem_reservation: "192m"
     environment:
       - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=4
       - DATASOURCE_DB_CORE_MINIMUM_IDLE=1
-      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=3000
-      - JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=60.0 -XX:MinRAMPercentage=30.0 -XX:MaxGCPauseMillis=800
+      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=2000
+      - SYNC_JOB_PARALLELISM=4
+      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=55.0 -XX:MaxGCPauseMillis=400
 
   yogieat-db:
-    cpus: "0.40"
-    mem_limit: "640m"
-    mem_reservation: "320m"
+    cpus: "0.35"
+    mem_limit: "768m"
+    mem_reservation: "384m"
     environment:
       - PG_LOG_STATEMENT=none
       - PG_SHARED_BUFFERS=256MB
       - PG_WORK_MEM=8MB
       - PG_MAINTENANCE_WORK_MEM=64MB
-      - PG_MAX_CONNECTIONS=120
+      - PG_MAX_CONNECTIONS=48

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -7,7 +7,7 @@ services:
     environment:
       - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=18
       - DATASOURCE_DB_CORE_MINIMUM_IDLE=4
-      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=1500
+      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=3000
       - API_TOMCAT_MAX_THREADS=128
       - API_TOMCAT_MIN_THREADS=16
       - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=65.0 -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication
@@ -26,14 +26,14 @@ services:
 
   yogieat-batch-sync:
     cpus: "0.20"
-    mem_limit: "384m"
-    mem_reservation: "192m"
+    mem_limit: "512m"
+    mem_reservation: "256m"
     environment:
       - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=4
       - DATASOURCE_DB_CORE_MINIMUM_IDLE=1
       - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=2000
       - SYNC_JOB_PARALLELISM=4
-      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=55.0 -XX:MaxGCPauseMillis=400
+      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=50.0 -XX:MaxGCPauseMillis=400
 
   yogieat-db:
     cpus: "0.35"

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -1,35 +1,47 @@
 # Prod 2vCore, 4GB RAM, 50GB Storage
 services:
   yogieat-api:
-    cpus: "0.90"
-    mem_limit: "1440m"
-    mem_reservation: "720m"
+    cpus: "1.00"
+    mem_limit: "1536m"
+    mem_reservation: "768m"
     environment:
-      - API_TOMCAT_MAX_THREADS=320
-      - API_TOMCAT_MIN_THREADS=40
-      - JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=70.0 -XX:MinRAMPercentage=35.0 -XX:MaxGCPauseMillis=400
+      - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=18
+      - DATASOURCE_DB_CORE_MINIMUM_IDLE=4
+      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=1500
+      - API_TOMCAT_MAX_THREADS=128
+      - API_TOMCAT_MIN_THREADS=16
+      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=65.0 -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication
 
   yogieat-admin:
-    cpus: "0.50"
-    mem_limit: "800m"
-    mem_reservation: "400m"
+    cpus: "0.25"
+    mem_limit: "512m"
+    mem_reservation: "256m"
     environment:
-      - JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=60.0 -XX:MinRAMPercentage=30.0 -XX:MaxGCPauseMillis=600
+      - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=6
+      - DATASOURCE_DB_CORE_MINIMUM_IDLE=2
+      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=2000
+      - ADMIN_TOMCAT_MAX_THREADS=32
+      - ADMIN_TOMCAT_MIN_THREADS=4
+      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=55.0 -XX:MaxGCPauseMillis=300
 
   yogieat-batch-sync:
     cpus: "0.20"
-    mem_limit: "320m"
-    mem_reservation: "160m"
+    mem_limit: "384m"
+    mem_reservation: "192m"
     environment:
-      - JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=60.0 -XX:MinRAMPercentage=30.0 -XX:MaxGCPauseMillis=800
+      - DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=4
+      - DATASOURCE_DB_CORE_MINIMUM_IDLE=1
+      - DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=2000
+      - SYNC_JOB_PARALLELISM=4
+      - JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=55.0 -XX:MaxGCPauseMillis=400
 
   yogieat-db:
-    cpus: "0.40"
-    mem_limit: "640m"
-    mem_reservation: "320m"
+    cpus: "0.35"
+    mem_limit: "768m"
+    mem_reservation: "384m"
     environment:
       - PG_LOG_STATEMENT=none
       - PG_SHARED_BUFFERS=256MB
       - PG_WORK_MEM=8MB
       - PG_MAINTENANCE_WORK_MEM=64MB
-      - PG_MAX_CONNECTIONS=120
+      - PG_MAX_CONNECTIONS=48

--- a/docs/operations/instance-deployment-api-batch.md
+++ b/docs/operations/instance-deployment-api-batch.md
@@ -1,6 +1,6 @@
 # API + Admin + Batch 인스턴스 배포/운영 가이드
 
-> 최종 업데이트: 2026-03-09
+> 최종 업데이트: 2026-04-22
 
 ## 1. 결론 요약
 - `batch:sync`는 API와 **별도 애플리케이션 프로세스**로 실행해야 한다.
@@ -48,16 +48,32 @@ location /api/ {
 - Admin 이미지: `yogieat/yogieat-server-admin:<tag>`
 - Batch 이미지: `yogieat/yogieat-server-batch-sync:<tag>`
 
-Dockerfile은 동일하고 `JAR_FILE` build-arg만 다르게 사용한다.
-- API: `apps/api/build/libs/*.jar`
-- Admin: `apps/admin/build/libs/*.jar`
-- Batch: `batch/sync/build/libs/*.jar`
+### 이미지 빌드 표준
+- 표준 빌드 경로는 Gradle `Jib`이다.
+- Jib는 Gradle에서 직접 레이어드 이미지를 만들고 Docker daemon 없이 registry push를 수행한다.
+- 변경되지 않은 dependency layer를 재사용하므로 `Dockerfile + buildx` 대비 CI 빌드와 push 시간이 줄어든다.
+- 이미지 내부 GC/JVM 옵션은 하드코딩하지 않고, Compose의 `JAVA_TOOL_OPTIONS`로만 제어한다.
+
+### Jib 태스크
+- CI 표준 태스크: `./gradlew jibPushAll --no-daemon`
+- 로컬 Docker 검증 태스크: `./gradlew jibDockerBuildAll --no-daemon`
+- 공통 전제:
+  - API 대상 이미지 env: `API_IMAGE_FULL_URL`
+  - Admin 대상 이미지 env: `ADMIN_IMAGE_FULL_URL`
+  - Batch 대상 이미지 env: `BATCH_IMAGE_FULL_URL`
+  - Registry 인증 env: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
+
+### Dockerfile fallback
+- `docker/Dockerfile`은 비상시 fallback 용도로만 유지한다.
+- 기본 CI/CD 경로에서는 사용하지 않는다.
+- fallback Dockerfile도 GC를 내장하지 않으며, `JAVA_TOOL_OPTIONS`에만 의존한다.
 
 ### CI/CD 동작
 1. Gradle build
-2. API/Admin/BATCH 이미지 각각 build & push
-3. 서버로 `docker/` 디렉터리 및 `scripts/deploy/` rsync
-4. 서버에서 `DEPLOY_SCOPE=app`, `DEPLOY_ENV=(dev|prod)`로 `scripts/deploy/compose-up.sh` 실행
+2. 이미지 태그 계산
+3. `./gradlew jibPushAll --no-daemon`으로 API/Admin/BATCH 이미지 push
+4. 서버로 `docker/` 디렉터리 및 `scripts/deploy/` rsync
+5. 서버에서 `DEPLOY_SCOPE=app`, `DEPLOY_ENV=(dev|prod)`로 `scripts/deploy/compose-up.sh` 실행
 
 ## 5. 인스턴스 실행 방법
 
@@ -104,16 +120,40 @@ ENV_FILE_PATH=~/.env \
 ### 5.2 환경별 리소스 제한
 - DEV (`docker/docker-compose.dev.yaml`)
   - 서버 스펙 목표: `2 vCPU / 4GB`
-  - `yogieat-api`: `cpus=0.90`, `mem_limit=1440m`, `mem_reservation=720m`
-  - `yogieat-admin`: `cpus=0.50`, `mem_limit=800m`, `mem_reservation=400m`
-  - `yogieat-batch-sync`: `cpus=0.20`, `mem_limit=320m`, `mem_reservation=160m`
-  - `yogieat-db`: `cpus=0.40`, `mem_limit=640m`, `mem_reservation=320m`
+  - `yogieat-api`: `cpus=1.00`, `mem_limit=1536m`, `mem_reservation=768m`
+  - `yogieat-api` env:
+    - `DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=18`
+    - `DATASOURCE_DB_CORE_MINIMUM_IDLE=4`
+    - `DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=1500`
+    - `API_TOMCAT_MAX_THREADS=128`
+    - `API_TOMCAT_MIN_THREADS=16`
+    - `JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=65.0 -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication`
+  - `yogieat-admin`: `cpus=0.25`, `mem_limit=512m`, `mem_reservation=256m`
+  - `yogieat-admin` env:
+    - `DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=6`
+    - `DATASOURCE_DB_CORE_MINIMUM_IDLE=2`
+    - `DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=2000`
+    - `ADMIN_TOMCAT_MAX_THREADS=32`
+    - `ADMIN_TOMCAT_MIN_THREADS=4`
+    - `JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=55.0 -XX:MaxGCPauseMillis=300`
+  - `yogieat-batch-sync`: `cpus=0.20`, `mem_limit=384m`, `mem_reservation=192m`
+  - `yogieat-batch-sync` env:
+    - `DATASOURCE_DB_CORE_MAXIMUM_POOL_SIZE=4`
+    - `DATASOURCE_DB_CORE_MINIMUM_IDLE=1`
+    - `DATASOURCE_DB_CORE_CONNECTION_TIMEOUT=2000`
+    - `SYNC_JOB_PARALLELISM=4`
+    - `JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:MaxRAMPercentage=55.0 -XX:MaxGCPauseMillis=400`
+  - `yogieat-db`: `cpus=0.35`, `mem_limit=768m`, `mem_reservation=384m`
+  - `yogieat-db` env:
+    - `PG_SHARED_BUFFERS=256MB`
+    - `PG_WORK_MEM=8MB`
+    - `PG_MAINTENANCE_WORK_MEM=64MB`
+    - `PG_MAX_CONNECTIONS=48`
 - PROD (`docker/docker-compose.prod.yaml`)
   - 서버 스펙 목표: `2 vCPU / 4GB`
-  - `yogieat-api`: `cpus=0.90`, `mem_limit=1440m`, `mem_reservation=720m`
-  - `yogieat-admin`: `cpus=0.50`, `mem_limit=800m`, `mem_reservation=400m`
-  - `yogieat-batch-sync`: `cpus=0.20`, `mem_limit=320m`, `mem_reservation=160m`
-  - `yogieat-db`: `cpus=0.40`, `mem_limit=640m`, `mem_reservation=320m`
+  - `DEV`와 동일한 `2 vCPU / 4GB 처리량 우선` 프로파일을 사용한다.
+
+서비스 합산 자원 사용량은 `1.80 vCPU`, `3200MiB`로 맞춰 OS/nginx/docker 여유를 남긴다.
 
 `DEPLOY_SCOPE=app` 배포는 API/Admin/BATCH 중심으로 동작하며, DB는 필요 시 자동 복구(기동/재생성)된다.
 DB 설정을 강제로 재적용하려면 유지보수 창에 `DEPLOY_SCOPE=full` 배포를 사용한다.
@@ -186,3 +226,4 @@ docker logs -f yogieat-server-batch-sync
 ## 11. 주의사항
 - 이 저장소 변경은 배포 아티팩트를 준비한 것이며, 실제 서버 반영은 CI 실행 또는 서버에서 compose 명령 실행이 필요하다.
 - 운영은 nginx/letsencrypt 기준으로 관리한다. Caddy edge는 운영 기본 경로가 아니다.
+- Jib는 현재 Gradle 9.1.0 환경에서 실검증 대상이다. 배포 전 최소 `./gradlew jibDockerBuildAll --no-daemon`까지는 확인한다.


### PR DESCRIPTION
## 🌱 관련 이슈

- close #

## 📌 작업 내용

- Jib 기반 이미지 빌드/배포 경로를 추가했습니다.
  - `docker buildx` 대신 `./gradlew jibPushAll --no-daemon`으로 API/Admin/Batch 이미지를 push하도록 CI를 변경했습니다.
  - 루트 Gradle에 `jibPushAll`, `jibDockerBuildAll` 집계 태스크를 추가했습니다.
- API/Admin/Batch 서비스에 Jib 설정을 추가했습니다.
  - `amazoncorretto:25-alpine-jdk` 기반으로 이미지 빌드
  - `mainClass` 명시
  - 기존 이미지명 및 compose 배포 흐름은 유지
- 2Core/4GB 환경 기준으로 compose 런타임 리소스를 조정했습니다.
  - API/Admin/Batch/DB의 CPU, 메모리 제한 재조정
  - API/Admin Tomcat thread, DB pool, Batch parallelism, JVM 옵션 튜닝
- Admin과 Batch 런타임 설정을 보완했습니다.
  - `ADMIN_TOMCAT_MAX_THREADS`, `ADMIN_TOMCAT_MIN_THREADS` 추가
  - `SYNC_JOB_PARALLELISM` env 주입 가능하도록 변경
- 운영 문서를 Jib 배포 및 2Core/4GB 기준으로 갱신했습니다.
- 맛집 수집 지역 제한을 전 지역 100개로 통일했습니다. (잠수함 패치)
  - 기존 일부 지역 50개 제한 제거
- `develop_build_deploy.yml`의 push 브랜치는 브랜치 검증을 위해 `chore/jib`로 조정했습니다.

## 📝 참고

## 💬 리뷰 요구사항(선택)
