### PR TITLE
[Fix] 신규 수집 시 off_days_updated_at NULL 저장 버그 수정

### DIFF
--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
@@ -141,7 +141,8 @@ public class RestaurantEntity extends BaseEntity {
             // 추천 시간대
             TimeSlot timeSlot,
             // 휴무일
-            String offDays) {
+            String offDays,
+            LocalDateTime offDaysUpdatedAt) {
         this.externalId = externalId;
         this.name = name;
         this.address = address;
@@ -162,6 +163,7 @@ public class RestaurantEntity extends BaseEntity {
         this.aiMateSummaryContents = aiMateSummaryContents;
         this.timeSlot = timeSlot;
         this.offDays = offDays;
+        this.offDaysUpdatedAt = offDaysUpdatedAt;
     }
 
     /**
@@ -203,6 +205,10 @@ public class RestaurantEntity extends BaseEntity {
                 .timeSlot(createRestaurant.timeSlot())
                 // 휴무일
                 .offDays(createRestaurant.offDays())
+                .offDaysUpdatedAt(
+                        createRestaurant.offDays() != null
+                                ? LocalDateTime.now()
+                                : null)
                 .build();
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #159

## 📌 작업 내용
- `RestaurantEntity.from(CreateRestaurant)` 빌더에 `offDaysUpdatedAt` 세팅 추가

## 📝 참고
- 동기화 경로(`applySyncPatch`, `batchApplySyncPatch`)는 이미 두 컬럼을 함께 갱신하고 있어 정상
- 기존에 null로 저장된 식당은 다음 동기화(매일 02시) 시점에 자동으로 채워짐(kakao api 정상 응답일 시)

## 💬 리뷰 요구사항(선택)

-