### PR TITLE
[Feature] 맛집 노출 여부 필드 추가 및 사용자 조회 조건 반영

### DIFF
--- a/apps/admin/src/main/java/com/yogieat/controller/v1/restaurant/request/RestaurantRequest.java
+++ b/apps/admin/src/main/java/com/yogieat/controller/v1/restaurant/request/RestaurantRequest.java
@@ -60,7 +60,8 @@ public final class RestaurantRequest {
             String priceLevel,
             String aiMateSummaryTitle,
             List<String> aiMateSummaryContents,
-            String timeSlot
+            String timeSlot,
+            Boolean isDisplay
     ) {
         public static Patch from(
                 String externalId,
@@ -81,7 +82,8 @@ public final class RestaurantRequest {
                 String priceLevel,
                 String aiMateSummaryTitle,
                 List<String> aiMateSummaryContents,
-                String timeSlot
+                String timeSlot,
+                Boolean isDisplay
         ) {
             return new Patch(
                     externalId,
@@ -102,12 +104,14 @@ public final class RestaurantRequest {
                     priceLevel,
                     aiMateSummaryTitle,
                     aiMateSummaryContents,
-                    timeSlot
+                    timeSlot,
+                    isDisplay
             );
         }
 
         public static Patch of() {
             return new Patch(
+                    null,
                     null,
                     null,
                     null,
@@ -155,7 +159,7 @@ public final class RestaurantRequest {
                     trimOrNull(request.aiMateSummaryTitle()),
                     trimAiMateSummaryContents(request.aiMateSummaryContents()),
                     parseTimeSlot(request.timeSlot()),
-                    null
+                    request.isDisplay()
             );
         }
     }

--- a/apps/admin/src/main/java/com/yogieat/controller/v1/restaurant/request/RestaurantRequest.java
+++ b/apps/admin/src/main/java/com/yogieat/controller/v1/restaurant/request/RestaurantRequest.java
@@ -154,7 +154,8 @@ public final class RestaurantRequest {
                     trimOrNull(request.priceLevel()),
                     trimOrNull(request.aiMateSummaryTitle()),
                     trimAiMateSummaryContents(request.aiMateSummaryContents()),
-                    parseTimeSlot(request.timeSlot())
+                    parseTimeSlot(request.timeSlot()),
+                    null
             );
         }
     }

--- a/apps/admin/src/test/java/com/yogieat/controller/v1/restaurant/fixture/RestaurantAdminFixture.java
+++ b/apps/admin/src/test/java/com/yogieat/controller/v1/restaurant/fixture/RestaurantAdminFixture.java
@@ -91,6 +91,7 @@ public final class RestaurantAdminFixture {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }
@@ -115,6 +116,7 @@ public final class RestaurantAdminFixture {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }
@@ -131,6 +133,7 @@ public final class RestaurantAdminFixture {
                 null,
                 null,
                 "INVALID_REGION",
+                null,
                 null,
                 null,
                 null,
@@ -163,7 +166,8 @@ public final class RestaurantAdminFixture {
                 null,
                 null,
                 null,
-                "INVALID_SLOT"
+                "INVALID_SLOT",
+                null
         );
     }
 }

--- a/apps/api/src/test/java/com/yogieat/region/RegionMigrationIntegrationTest.java
+++ b/apps/api/src/test/java/com/yogieat/region/RegionMigrationIntegrationTest.java
@@ -364,7 +364,8 @@ class RegionMigrationIntegrationTest {
                 "[\"요약\"]",
                 TimeSlot.LUNCH,
                 null,
-                "010-0000-0000"
+                "010-0000-0000",
+                Boolean.TRUE
         );
     }
 
@@ -375,6 +376,7 @@ class RegionMigrationIntegrationTest {
                 null,
                 null,
                 region,
+                null,
                 null,
                 null,
                 null,

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
@@ -33,7 +33,8 @@ public record CreateRestaurant(
         TimeSlot timeSlot,
         // 휴무일
         String offDays,  // JSON 문자열로 저장
-        String phoneNumber
+        String phoneNumber,
+        Boolean isDisplay
 ) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -60,7 +61,8 @@ public record CreateRestaurant(
             TimeSlot timeSlot,
             // 휴무일 파라미터
             List<LocalDate> offDays,
-            String phoneNumber
+            String phoneNumber,
+            Boolean isDisplay
     ) {
         return new CreateRestaurant(
                 externalId,
@@ -83,7 +85,8 @@ public record CreateRestaurant(
                 toJson(aiMateSummaryContents),
                 timeSlot,
                 offDaysToJson(offDays),
-                phoneNumber
+                phoneNumber,
+                isDisplay
         );
     }
 
@@ -143,7 +146,8 @@ public record CreateRestaurant(
                 toJson(detail == null ? null : detail.aiMateSummaryContents()),
                 detail == null ? null : detail.timeSlot(),
                 offDaysToJson(detail == null ? null : detail.offDays()),
-                detail == null ? null : detail.phoneNumber()
+                detail == null ? null : detail.phoneNumber(),
+                null
         );
     }
 

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/CreateRestaurant.java
@@ -147,7 +147,7 @@ public record CreateRestaurant(
                 detail == null ? null : detail.timeSlot(),
                 offDaysToJson(detail == null ? null : detail.offDays()),
                 detail == null ? null : detail.phoneNumber(),
-                null
+                false
         );
     }
 

--- a/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/domain/Restaurant.java
@@ -35,6 +35,7 @@ public record Restaurant(
         LocalDateTime updatedAt,
         // 휴무일
         List<LocalDate> offDays,
-        String phoneNumber
+        String phoneNumber,
+        Boolean isDisplay
 ){
 }

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionWriteService.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCollectionWriteService.java
@@ -73,7 +73,8 @@ public class RestaurantCollectionWriteService {
                     enrichedData.aiMateSummaryContents(),
                     enrichedData.timeSlot(),
                     enrichedData.offDays(),
-                    enrichedData.phoneNumber()
+                    enrichedData.phoneNumber(),
+                    Boolean.TRUE
             );
 
             restaurantRepository.save(createRestaurant, restaurantRegion.id());

--- a/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCommand.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/service/RestaurantCommand.java
@@ -37,10 +37,12 @@ public final class RestaurantCommand {
             String priceLevel,
             String aiMateSummaryTitle,
             List<String> aiMateSummaryContents,
-            TimeSlot timeSlot
+            TimeSlot timeSlot,
+            Boolean isDisplay
     ) {
         public static Patch empty() {
             return new Patch(
+                    null,
                     null,
                     null,
                     null,

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
@@ -148,7 +148,8 @@ class RecommendResultFacadeTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         );
     }
 }

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
@@ -633,7 +633,8 @@ class RecommendationProcessorTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         );
     }
 

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/strategy/CategoryQuotaSelectionStrategyTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/strategy/CategoryQuotaSelectionStrategyTest.java
@@ -106,7 +106,8 @@ class CategoryQuotaSelectionStrategyTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         );
 
         return new CategoryScoredRestaurant(

--- a/apps/domain/src/test/java/com/yogieat/restaurant/fixture/RestaurantFixture.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/fixture/RestaurantFixture.java
@@ -36,7 +36,8 @@ public final class RestaurantFixture {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         );
     }
 
@@ -65,7 +66,8 @@ public final class RestaurantFixture {
                 source.createdAt(),
                 source.updatedAt(),
                 null,
-                null
+                null,
+                true
         );
     }
 
@@ -89,7 +91,8 @@ public final class RestaurantFixture {
                 "2-3",
                 "updated-summary-title",
                 List.of("summary"),
-                TimeSlot.BOTH
+                TimeSlot.BOTH,
+                true
         );
     }
 

--- a/apps/domain/src/test/java/com/yogieat/restaurant/service/RestaurantValidatorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/service/RestaurantValidatorTest.java
@@ -122,7 +122,8 @@ class RestaurantValidatorTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         );
     }
 }

--- a/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncJobServiceTest.java
+++ b/apps/domain/src/test/java/com/yogieat/restaurant/sync/service/RestaurantSyncJobServiceTest.java
@@ -89,7 +89,8 @@ class RestaurantSyncJobServiceTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         )));
         when(syncJobRepository.existsByTargetRestaurantIdAndStatus(1L, RestaurantSyncJobStatus.RUNNING)).thenReturn(false);
         when(syncJobRepository.existsByTargetRestaurantIdAndStatus(1L, RestaurantSyncJobStatus.PENDING)).thenReturn(false);
@@ -177,7 +178,8 @@ class RestaurantSyncJobServiceTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                true
         )));
         when(syncJobRepository.existsByTargetRestaurantIdAndStatus(1L, RestaurantSyncJobStatus.RUNNING)).thenReturn(false);
         when(syncJobRepository.existsByTargetRestaurantIdAndStatus(1L, RestaurantSyncJobStatus.PENDING)).thenReturn(false);

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
@@ -159,7 +159,8 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                         restaurantEntity.createdAt,
                         restaurantEntity.updatedAt,
                         restaurantEntity.offDays,
-                        restaurantEntity.phoneNumber
+                        restaurantEntity.phoneNumber,
+                        restaurantEntity.isDisplay
                 )
                 .from(restaurantEntity)
                 .where(
@@ -532,7 +533,8 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                 tuple.get(restaurantEntity.createdAt),
                 tuple.get(restaurantEntity.updatedAt),
                 parseOffDays(tuple.get(restaurantEntity.offDays)),
-                tuple.get(restaurantEntity.phoneNumber)
+                tuple.get(restaurantEntity.phoneNumber),
+                tuple.get(restaurantEntity.isDisplay)
         );
     }
 

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
@@ -370,8 +370,11 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                 .on(restaurantEntity.categoryId.eq(categoryEntity.id))
                 .leftJoin(regionEntity)
                 .on(restaurantEntity.regionId.eq(regionEntity.id))
-                .where(restaurantEntity.deletedAt.isNull())
-                .where(restaurantEntity.id.eq(restaurantId))
+                .where(
+                        restaurantEntity.deletedAt.isNull(),
+                        restaurantEntity.isDisplay.isTrue(),
+                        restaurantEntity.id.eq(restaurantId)
+                )
                 .fetchOne();
 
         if (tuple == null) {

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantCoreRepository.java
@@ -165,6 +165,7 @@ public class RestaurantCoreRepository implements RestaurantRepository {
                 .from(restaurantEntity)
                 .where(
                         restaurantEntity.deletedAt.isNull(),
+                        restaurantEntity.isDisplay.isTrue(),
                         regionCondition(region),
                         restaurantEntity.categoryId.in(categoryIds),
                         recommendationTimeSlotCondition(gatheringTimeSlot),

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
@@ -122,6 +122,9 @@ public class RestaurantEntity extends BaseEntity {
     @Column(name = "phone_number", length = 50)
     private String phoneNumber;
 
+    @Column(name = "is_display")
+    private Boolean isDisplay;
+
     @Builder(access = AccessLevel.PRIVATE)
     private RestaurantEntity(
             String externalId,
@@ -149,7 +152,8 @@ public class RestaurantEntity extends BaseEntity {
             // 휴무일
             String offDays,
             LocalDateTime offDaysUpdatedAt,
-            String phoneNumber) {
+            String phoneNumber,
+            Boolean isDisplay) {
         this.externalId = externalId;
         this.name = name;
         this.address = address;
@@ -173,6 +177,8 @@ public class RestaurantEntity extends BaseEntity {
         this.offDays = offDays;
         this.offDaysUpdatedAt = offDaysUpdatedAt;
         this.phoneNumber = phoneNumber;
+        // null 인 경우 NOT NULL 컬럼 제약을 위반하지 않도록 기본값 true로 보정
+        this.isDisplay = isDisplay != null ? isDisplay : Boolean.TRUE;
     }
 
     /**
@@ -219,6 +225,7 @@ public class RestaurantEntity extends BaseEntity {
                                 ? LocalDateTime.now()
                                 : null)
                 .phoneNumber(createRestaurant.phoneNumber())
+                .isDisplay(createRestaurant.isDisplay())
                 .build();
     }
 
@@ -253,7 +260,8 @@ public class RestaurantEntity extends BaseEntity {
                 entity.getUpdatedAt(),
                 // 휴무일
                 parseOffDays(entity.getOffDays()),
-                entity.getPhoneNumber()
+                entity.getPhoneNumber(),
+                entity.getIsDisplay()
         );
     }
 
@@ -408,6 +416,9 @@ public class RestaurantEntity extends BaseEntity {
         }
         if (command.timeSlot() != null) {
             this.timeSlot = command.timeSlot();
+        }
+        if (command.isDisplay() != null) {
+            this.isDisplay = command.isDisplay();
         }
     }
 

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/restaurant/RestaurantEntity.java
@@ -122,7 +122,7 @@ public class RestaurantEntity extends BaseEntity {
     @Column(name = "phone_number", length = 50)
     private String phoneNumber;
 
-    @Column(name = "is_display")
+    @Column(name = "is_display", nullable = false)
     private Boolean isDisplay;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/storage/db-core/src/main/resources/db/migration/V8__add_is_display_to_restaurant.sql
+++ b/storage/db-core/src/main/resources/db/migration/V8__add_is_display_to_restaurant.sql
@@ -1,0 +1,2 @@
+ALTER TABLE t_restaurant
+    ADD COLUMN is_display BOOLEAN NOT NULL DEFAULT TRUE;

--- a/storage/db-core/src/main/resources/db/migration/V9__update_restaurant_recommendation_index.sql
+++ b/storage/db-core/src/main/resources/db/migration/V9__update_restaurant_recommendation_index.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_restaurant_active_region_category_time_slot;
+
+CREATE INDEX IF NOT EXISTS idx_restaurant_active_region_category_time_slot
+    ON t_restaurant(region_id, category_id, time_slot)
+    WHERE deleted_at IS NULL
+    AND is_display = TRUE;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #171

## 📌 작업 내용

- `Restaurant` 도메인 및 `RestaurantEntity`에 `isDisplay`(Boolean) 필드 추가
- `t_restaurant` 테이블에 `is_display` `BOOLEAN NOT NULL DEFAULT TRUE` 컬럼 추가 (V8 Flyway 마이그레이션)
- 맛집 추천 및 재추천 시 `isDisplay = true`인 맛집만 후보에 포함되도록 필터 적용
- 맛집 상세 조회(`GET` `/api/v1/restaurants/{restaurantId}`) 시 `isDisplay = false`인 맛집은 404 반환
- 추천 후보 조회 인덱스(`idx_restaurant_active_region_category_time_slot`)의 부분 인덱스 조건에 `is_display = TRUE` 추가하여 스캔 범위 축소 (V9 Flyway 마이그레이션)

## 📝 참고
- `isDisplay = false`인 맛집도 동기화 대상에는 포함되도록 유지
    - 운영자가 다시 노출 상태로 변경할 가능성과 어드민 내 데이터 최신 상태 유지를 고려
- 기존 추천 결과에 포함된 맛집은 `isDisplay = false` 상태가 되더라도 그대로 조회 가능하도록 유지
    - 사용자가 이미 추천받은 결과를 다시 확인하는 상황 고려
- `true`/`false` 모두 조회되어야 하는 영역은 별도 where 조건을 추가하지 않았고, 사용자 노출이 필요한 조회 영역에만 `isDisplay = true` 조건 적용
- 컬럼 기본값이 `TRUE`이므로 기존 행은 마이그레이션 후 자동으로 노출 상태로 설정됨
- 기존 데이터의 `isDisplay` 값은 머지 이후 별도 작업으로 일괄 `true` 세팅 예정
- 어드민 내 맛집 리스트 조회(true, false 전체 노출) 및 추천 진행 중 isDisplay 변경 제한 등도 고민하였으나, 어드민 개발 영역으로 판단하여 해당 작업 범위에서는 진행 x (해당 작업 범위에서 필요 시 추가하겠습니다!)

## 💬 리뷰 요구사항(선택)

- 사용자 노출 영역 중 `isDisplay` 조건이 추가로 필요한 곳이 있는지 확인 부탁드립니다!