### PR TITLE
[Feature] 맛집 수집 거리 반경 1km -> 700m로 변경

### DIFF
--- a/apps/domain/src/main/java/com/yogieat/restaurant/sync/service/RestaurantSyncService.java
+++ b/apps/domain/src/main/java/com/yogieat/restaurant/sync/service/RestaurantSyncService.java
@@ -47,7 +47,7 @@ public class RestaurantSyncService {
     private static final Logger log = LoggerFactory.getLogger(RestaurantSyncService.class);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final double SYNC_REGION_RADIUS_KM = 1.0;
+    private static final double SYNC_REGION_RADIUS_KM = 0.7;
     private static final int DB_BATCH_SIZE = 300;
     private static final String SEARCH_CACHE_PREFIX = "search:";
     private static final String DETAIL_CACHE_PREFIX = "detail:";

--- a/storage/db-core/src/main/resources/db/migration/V10__hide_restaurants_out_of_700m_radius.sql
+++ b/storage/db-core/src/main/resources/db/migration/V10__hide_restaurants_out_of_700m_radius.sql
@@ -1,0 +1,11 @@
+UPDATE t_restaurant r
+SET is_display = false,
+    updated_at = NOW()
+FROM t_region reg
+WHERE r.region_id = reg.id
+  AND r.deleted_at IS NULL
+  AND r.is_display = true
+  AND ST_Distance(
+          r.location::geography,
+          ST_SetSRID(ST_MakePoint(reg.longitude, reg.latitude), 4326)::geography
+      ) > 700;

--- a/storage/db-core/src/main/resources/db/migration/V10__hide_restaurants_out_of_700m_radius.sql
+++ b/storage/db-core/src/main/resources/db/migration/V10__hide_restaurants_out_of_700m_radius.sql
@@ -5,7 +5,8 @@ FROM t_region reg
 WHERE r.region_id = reg.id
   AND r.deleted_at IS NULL
   AND r.is_display = true
-  AND ST_Distance(
+  AND NOT ST_DWithin(
           r.location::geography,
-          ST_SetSRID(ST_MakePoint(reg.longitude, reg.latitude), 4326)::geography
-      ) > 700;
+          ST_SetSRID(ST_MakePoint(reg.longitude, reg.latitude), 4326)::geography,
+          700
+      );


### PR DESCRIPTION
## 🌱 관련 이슈

- close #177

## 📌 작업 내용

- 맛집 수집 반경 기준을 1km에서 700m로 축소
- 기존에 등록된 700m 초과 맛집 데이터를 미노출(`is_display = false`) 처리하는 Flyway 마이그레이션 추가 (V10)

## 📝 참고

- 반경 기준은 `RestaurantSyncService.SYNC_REGION_RADIUS_KM` 상수 하나로 관리되며, sync 시 700m 초과 맛집은 기존과 동일하게 소프트 삭제됨
- 기존 데이터 미노출 처리는 일회성 작업으로 코드 구현 대신 Flyway 마이그레이션으로 처리

## 💬 리뷰 요구사항(선택)

-