### PR TITLE
[Feature] 추천 맛집 상세 리스트 조회 API 구현 (v2)

### DIFF
--- a/apps/api/build.gradle
+++ b/apps/api/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     // API runtime
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    runtimeOnly 'org.postgresql:postgresql'
 
     // Validation (used only by apps:api for request validation)
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/apps/api/src/main/java/com/yogieat/controller/v1/recommend/RecommendResultV1Controller.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v1/recommend/RecommendResultV1Controller.java
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "🍽 RecommendResult API", description = "추천 결과 관련 API")
+@Tag(name = "🍽 RecommendResult API (v1)", description = "추천 결과 관련 API (v1)")
 @RestController
 @RequestMapping("/api/v1/recommend-results")
 @RequiredArgsConstructor
-public class RecommendResultController {
+public class RecommendResultV1Controller {
     private final RecommendResultFacade recommendResultFacade;
 
     @Operation(summary = "추천 결과 조회", description = "모임의 추천 결과를 조회합니다.")

--- a/apps/api/src/main/java/com/yogieat/controller/v2/recommend/RecommendResultV2Controller.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v2/recommend/RecommendResultV2Controller.java
@@ -1,0 +1,30 @@
+package com.yogieat.controller.v2.recommend;
+
+import com.yogieat.controller.v2.recommend.response.GetRecommendResultResponse;
+import com.yogieat.recommend.service.RecommendResultFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "🍽 RecommendResult API (v2)", description = "추천 결과 관련 API (v2)")
+@RestController
+@RequestMapping("/api/v2/recommend-results")
+@RequiredArgsConstructor
+public class RecommendResultV2Controller {
+
+    private final RecommendResultFacade recommendResultFacade;
+
+    @Operation(summary = "추천 결과 조회", description = "모임의 추천 결과를 조회합니다.")
+    @GetMapping("/{accessKey}")
+    public GetRecommendResultResponse getRecommendResults(
+            @PathVariable String accessKey
+    ) {
+        return GetRecommendResultResponse.from(
+                recommendResultFacade.getRecommendResultsV2(accessKey)
+        );
+    }
+}

--- a/apps/api/src/main/java/com/yogieat/controller/v2/recommend/response/GetRecommendResultResponse.java
+++ b/apps/api/src/main/java/com/yogieat/controller/v2/recommend/response/GetRecommendResultResponse.java
@@ -1,0 +1,61 @@
+package com.yogieat.controller.v2.recommend.response;
+
+import com.yogieat.common.Region;
+import com.yogieat.controller.v1.recommend.response.RankingRecommendResultResponse;
+import com.yogieat.gathering.domain.value.TimeSlot;
+import com.yogieat.recommend.domain.result.RecommendResultData;
+import com.yogieat.recommend.domain.value.RecommendStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "추천 결과 조회 응답 정보")
+public record GetRecommendResultResponse(
+        @Schema(description = "추천 처리 상태 (PENDING: 처리 중, COMPLETED: 완료, FAILED: 실패)", example = "COMPLETED")
+        RecommendStatus status,
+        @Schema(description = "추천 결과 맛집 리스트")
+        List<RankingRecommendResultResponse> recommendResults,
+        @Schema(description = "모임 정보")
+        GatheringInfo gathering,
+        @Schema(description = "카테고리별 선호도 집계", example = "{\"KOREAN\": 3, \"WESTERN\": 2}")
+        Map<String, Integer> preferences,
+        @Schema(description = "카테고리별 불호 집계", example = "{\"CHINESE\": 1}")
+        Map<String, Integer> dislikes,
+        @Schema(description = "거리 범위별 집계", example = "{\"RANGE_500M\": 2, \"RANGE_1KM\": 1, \"ANY\": 1}")
+        Map<String, Integer> distances,
+        @Schema(description = "의견 일치율 (%)", example = "85.5")
+        Double agreementRate
+) {
+    public record GatheringInfo(
+            LocalDate scheduledDate,
+            TimeSlot timeSlot,
+            Region region,
+            Integer peopleCount
+    ) {
+        public static GatheringInfo from(RecommendResultData.GatheringInfo info) {
+            return new GetRecommendResultResponse.GatheringInfo(
+                    info.scheduledDate(),
+                    info.timeSlot(),
+                    info.region(),
+                    info.peopleCount()
+            );
+        }
+    }
+
+    public static GetRecommendResultResponse from(RecommendResultData.Get result) {
+        List<RankingRecommendResultResponse> recommendResults = result.rankings().stream()
+                .map(RankingRecommendResultResponse::from)
+                .toList();
+
+        return new GetRecommendResultResponse(
+                result.status(),
+                recommendResults,
+                result.gathering() != null ? GatheringInfo.from(result.gathering()) : null,
+                result.preferences(),
+                result.dislikes(),
+                result.distances(),
+                result.averageAgreementRate()
+        );
+    }
+}

--- a/apps/api/src/test/java/com/yogieat/controller/v1/recommend/RecommendResultV1ControllerValidationTest.java
+++ b/apps/api/src/test/java/com/yogieat/controller/v1/recommend/RecommendResultV1ControllerValidationTest.java
@@ -9,12 +9,12 @@ import java.lang.reflect.Parameter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class RecommendResultControllerValidationTest {
+class RecommendResultV1ControllerValidationTest {
 
     @Test
     @DisplayName("재추천 API 요청 바디 파라미터에 @Valid가 선언되어 있다")
     void rerollRequestBodyParameter_ShouldHaveValidAnnotation() throws NoSuchMethodException {
-        Method method = RecommendResultController.class.getDeclaredMethod(
+        Method method = RecommendResultV1Controller.class.getDeclaredMethod(
                 "rerollRecommendResults",
                 RerollRecommendResultRequest.class
         );

--- a/apps/domain/src/main/java/com/yogieat/recommend/domain/result/RecommendResultData.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/domain/result/RecommendResultData.java
@@ -72,6 +72,18 @@ public record RecommendResultData() {
             );
         }
 
+        public static Get ofFailed(GatheringInfo gathering) {
+            return new Get(
+                RecommendStatus.FAILED,
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                0.0,
+                gathering
+            );
+        }
+
         public static Get ofEmpty(GatheringInfo gathering) {
             return new Get(
                 null,

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendRerollHistoryRepository.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendRerollHistoryRepository.java
@@ -1,7 +1,9 @@
 package com.yogieat.recommend.service;
 
 import com.yogieat.recommend.domain.RecommendRerollHistory;
+import java.util.Optional;
 
 public interface RecommendRerollHistoryRepository {
     RecommendRerollHistory save(RecommendRerollHistory recommendRerollHistory);
+    Optional<RecommendRerollHistory> findLatestByGatheringId(Long gatheringId);
 }

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendRerollHistoryService.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendRerollHistoryService.java
@@ -2,6 +2,7 @@ package com.yogieat.recommend.service;
 
 import com.yogieat.recommend.domain.RecommendRerollHistory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,5 +22,10 @@ public class RecommendRerollHistoryService {
         return recommendRerollHistoryRepository.save(
                 RecommendRerollHistory.Create.of(gatheringId, excludedRestaurantIds, rerolledResults)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RecommendRerollHistory> findLatestByGatheringId(Long gatheringId) {
+        return recommendRerollHistoryRepository.findLatestByGatheringId(gatheringId);
     }
 }

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
@@ -66,9 +66,13 @@ public class RecommendResultFacade {
             return RecommendResultData.Get.ofEmpty(gatheringInfo);
         }
 
-        // 4. PENDING 상태인 경우
-        if (recommendResults.getFirst().status() == RecommendStatus.PENDING) {
+        // 4. PENDING / FAILED 상태인 경우
+        RecommendStatus firstStatus = recommendResults.getFirst().status();
+        if (firstStatus == RecommendStatus.PENDING) {
             return RecommendResultData.Get.ofPending(gatheringInfo);
+        }
+        if (firstStatus == RecommendStatus.FAILED) {
+            return RecommendResultData.Get.ofFailed(gatheringInfo);
         }
 
         // 5. 참여자 목록 조회
@@ -130,9 +134,13 @@ public class RecommendResultFacade {
             return RecommendResultData.Get.ofEmpty(gatheringInfo);
         }
 
-        // 4. PENDING 상태인 경우
-        if (recommendResults.getFirst().status() == RecommendStatus.PENDING) {
+        // 4. PENDING / FAILED 상태인 경우
+        RecommendStatus firstStatus = recommendResults.getFirst().status();
+        if (firstStatus == RecommendStatus.PENDING) {
             return RecommendResultData.Get.ofPending(gatheringInfo);
+        }
+        if (firstStatus == RecommendStatus.FAILED) {
+            return RecommendResultData.Get.ofFailed(gatheringInfo);
         }
 
         // 5. 참여자 목록 조회

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
@@ -117,7 +117,6 @@ public class RecommendResultFacade {
                 .orElse(0.0) * 100.0) / 100.0;
     }
 
-    @Transactional
     public RecommendResultData.Get getRecommendResultsV2(String accessKey) {
         // 1. accessKey로 Gathering 조회
         Gathering gathering = gatheringService.getGatheringByAccessKey(accessKey);
@@ -161,29 +160,38 @@ public class RecommendResultFacade {
                         .toList()
         );
 
-        // 9. 저장된 reroll 이력이 있으면 재사용, 없으면 계산 후 저장
+        // 9. 저장된 reroll 이력이 있으면 재사용, 없으면 락 내에서 이중 검증 후 계산 저장
         List<RecommendRerollHistory.Result> rerollHistoryResults = recommendRerollHistoryService
                 .findLatestByGatheringId(gathering.id())
                 .map(RecommendRerollHistory::rerolledResults)
                 .orElse(null);
 
         if (rerollHistoryResults == null) {
-            int requestedCount = 9 - rankings.size();
-            RecommendationCandidateResult rerollCandidate = recommendationProcessor.calculateRecommendations(
-                    gathering.id(),
-                    gathering.region(),
-                    originalRestaurantIds,
-                    requestedCount
-            );
+            rerollHistoryResults = lockManager.executeWithLock(accessKey, () -> {
+                List<RecommendRerollHistory.Result> innerResults = recommendRerollHistoryService
+                        .findLatestByGatheringId(gathering.id())
+                        .map(RecommendRerollHistory::rerolledResults)
+                        .orElse(null);
+                if (innerResults != null) {
+                    return innerResults;
+                }
 
-            if (!rerollCandidate.failed()) {
-                rerollHistoryResults = toRerollHistoryResults(rerollCandidate.restaurants());
-                recommendRerollHistoryService.create(gathering.id(), originalRestaurantIds, rerollHistoryResults);
-                log.info("[V2] reroll 계산 완료 - gatheringId={}, 요청={}, 실제={}", gathering.id(), requestedCount, rerollHistoryResults.size());
-            } else {
-                log.warn("[V2] reroll 계산 실패 - gatheringId={}, reason={}, message={}", gathering.id(), rerollCandidate.failureReason(), rerollCandidate.failureMessage());
-                rerollHistoryResults = List.of();
-            }
+                int requestedCount = 9 - rankings.size();
+                RecommendationCandidateResult rerollCandidate = recommendationProcessor.calculateRecommendations(
+                        gathering.id(),
+                        gathering.region(),
+                        originalRestaurantIds,
+                        requestedCount
+                );
+
+                if (!rerollCandidate.failed()) {
+                    List<RecommendRerollHistory.Result> calculated = toRerollHistoryResults(rerollCandidate.restaurants());
+                    recommendRerollHistoryService.create(gathering.id(), originalRestaurantIds, calculated);
+                    return calculated;
+                } else {
+                    return List.<RecommendRerollHistory.Result>of();
+                }
+            });
         }
 
         // 10. reroll 이력 기반 나머지 맛집 빌드

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendResultFacade.java
@@ -118,6 +118,112 @@ public class RecommendResultFacade {
     }
 
     @Transactional
+    public RecommendResultData.Get getRecommendResultsV2(String accessKey) {
+        // 1. accessKey로 Gathering 조회
+        Gathering gathering = gatheringService.getGatheringByAccessKey(accessKey);
+        RecommendResultData.GatheringInfo gatheringInfo = RecommendResultData.GatheringInfo.of(gathering);
+
+        // 2. gatheringId로 RecommendResult 목록 조회 (rank 순서대로)
+        List<RecommendResult> recommendResults = recommendResultService.findByGatheringId(gathering.id());
+
+        // 3. 결과가 없는 경우
+        if (recommendResults.isEmpty()) {
+            return RecommendResultData.Get.ofEmpty(gatheringInfo);
+        }
+
+        // 4. PENDING 상태인 경우
+        if (recommendResults.getFirst().status() == RecommendStatus.PENDING) {
+            return RecommendResultData.Get.ofPending(gatheringInfo);
+        }
+
+        // 5. 참여자 목록 조회
+        List<Participant> participants = participantService.getByGatheringId(gathering.id());
+
+        // 6. 카테고리별 선호도/불호 집계
+        CategoryAggregation aggregation = participantAnalyzer.aggregateCategoryPreferences(participants);
+
+        // 6-1. DistanceRange별 집계
+        Map<String, Integer> distances = participantAnalyzer.aggregateDistanceRanges(participants);
+
+        // 7. Restaurant 정보와 Category 정보 조회 및 캐싱
+        List<Long> originalRestaurantIds = recommendResults.stream()
+                .map(RecommendResult::restaurantId)
+                .toList();
+        Map<Long, Restaurant> restaurantMap = restaurantService.findByIds(originalRestaurantIds).stream()
+                .collect(Collectors.toMap(Restaurant::id, Function.identity()));
+        Map<Long, Category> categoryMap = categoryService.findAll().stream()
+                .collect(Collectors.toMap(Category::id, Function.identity()));
+
+        // 8. 원본 추천 결과 (1~3위) 빌드
+        List<RecommendResultData.Ranking> rankings = new ArrayList<>(
+                recommendResults.stream()
+                        .map(result -> buildRankingResult(result, restaurantMap, categoryMap, gathering.region()))
+                        .toList()
+        );
+
+        // 9. 저장된 reroll 이력이 있으면 재사용, 없으면 계산 후 저장
+        List<RecommendRerollHistory.Result> rerollHistoryResults = recommendRerollHistoryService
+                .findLatestByGatheringId(gathering.id())
+                .map(RecommendRerollHistory::rerolledResults)
+                .orElse(null);
+
+        if (rerollHistoryResults == null) {
+            int requestedCount = 9 - rankings.size();
+            RecommendationCandidateResult rerollCandidate = recommendationProcessor.calculateRecommendations(
+                    gathering.id(),
+                    gathering.region(),
+                    originalRestaurantIds,
+                    requestedCount
+            );
+
+            if (!rerollCandidate.failed()) {
+                rerollHistoryResults = toRerollHistoryResults(rerollCandidate.restaurants());
+                recommendRerollHistoryService.create(gathering.id(), originalRestaurantIds, rerollHistoryResults);
+                log.info("[V2] reroll 계산 완료 - gatheringId={}, 요청={}, 실제={}", gathering.id(), requestedCount, rerollHistoryResults.size());
+            } else {
+                log.warn("[V2] reroll 계산 실패 - gatheringId={}, reason={}, message={}", gathering.id(), rerollCandidate.failureReason(), rerollCandidate.failureMessage());
+                rerollHistoryResults = List.of();
+            }
+        }
+
+        // 10. reroll 이력 기반 나머지 맛집 빌드
+        if (!rerollHistoryResults.isEmpty()) {
+            List<Long> rerollRestaurantIds = rerollHistoryResults.stream()
+                    .map(RecommendRerollHistory.Result::restaurantId)
+                    .toList();
+            Map<Long, Restaurant> rerollRestaurantMap = restaurantService.findByIds(rerollRestaurantIds).stream()
+                    .collect(Collectors.toMap(Restaurant::id, Function.identity()));
+
+            int nextRank = rankings.size() + 1;
+            for (RecommendRerollHistory.Result rerollResult : rerollHistoryResults) {
+                Restaurant restaurant = rerollRestaurantMap.get(rerollResult.restaurantId());
+                if (restaurant != null) {
+                    rankings.add(buildRankingResult(
+                            nextRank++,
+                            rerollResult.reasonText(),
+                            restaurant,
+                            categoryMap,
+                            gathering.region()
+                    ));
+                }
+            }
+        }
+
+        // 11. 평균 의견 일치율 계산 (소수점 둘째자리 반올림)
+        double averageAgreementRate = calculateAverageAgreementRate(recommendResults);
+
+        return RecommendResultData.Get.of(
+                RecommendStatus.COMPLETED,
+                List.copyOf(rankings),
+                aggregation.preferences(),
+                aggregation.dislikes(),
+                distances,
+                averageAgreementRate,
+                gatheringInfo
+        );
+    }
+
+    @Transactional
     public void proceedRecommendation(RecommendCommand.Proceed command) {
         lockManager.executeWithLock(command.accessKey(), () -> {
             // 1. Gathering 조회 (없음/삭제 시 예외 자동 발생)

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
@@ -136,6 +136,16 @@ public class RecommendationProcessor {
             Region region,
             List<Long> excludedRestaurantIds
     ) {
+        return calculateRecommendations(gatheringId, region, excludedRestaurantIds, scoringPolicy.candidate().topKSize());
+    }
+
+    @Transactional
+    public RecommendationCandidateResult calculateRecommendations(
+            Long gatheringId,
+            Region region,
+            List<Long> excludedRestaurantIds,
+            int topKSize
+    ) {
         Gathering gathering = gatheringRepository.findById(gatheringId).orElse(null);
         TimeSlot gatheringTimeSlot = gathering != null ? gathering.timeSlot() : null;
 
@@ -182,22 +192,23 @@ public class RecommendationProcessor {
 
         GeoJson.Point centerPoint = region.getCoordinatesStandard();
 
-        List<ScoredRestaurant> top3 = findTopRestaurantsWithFallback(
+        List<ScoredRestaurant> topRestaurants = findTopRestaurantsWithFallback(
                 restaurants,
                 categoryMap,
                 participantContext,
                 participants,
                 centerPoint,
-                gatheringTimeSlot
+                gatheringTimeSlot,
+                topKSize
         );
-        if (top3.isEmpty()) {
+        if (topRestaurants.isEmpty()) {
             return RecommendationCandidateResult.failure(
                     FailureReason.NO_RESTAURANTS,
                     "No suitable restaurants found after filtering"
             );
         }
 
-        return RecommendationCandidateResult.success(top3);
+        return RecommendationCandidateResult.success(topRestaurants);
     }
 
     private List<Restaurant> findRecommendationCandidates(
@@ -273,9 +284,8 @@ public class RecommendationProcessor {
             RecommendationParticipantContext participantContext,
             List<Participant> participants,
             GeoJson.Point centerPoint,
-            TimeSlot gatheringTimeSlot) {
-
-        int topKSize = scoringPolicy.candidate().topKSize();
+            TimeSlot gatheringTimeSlot,
+            int topKSize) {
 
         // 점수 계산은 1회만 수행하고, 필터 전략만 다르게 적용
         List<CategoryScoredRestaurant> scoredCandidates = scoreRestaurants(
@@ -288,7 +298,8 @@ public class RecommendationProcessor {
         List<ScoredRestaurant> primaryResults = selectTopRestaurantsByStrategy(
                 scoredCandidates,
                 participantContext,
-                FilterStrategy.PREFERENCE_SCORE_POSITIVE
+                FilterStrategy.PREFERENCE_SCORE_POSITIVE,
+                topKSize
         );
         if (primaryResults.size() >= topKSize) {
             return primaryResults;
@@ -298,7 +309,8 @@ public class RecommendationProcessor {
         List<ScoredRestaurant> fallbackResults = selectTopRestaurantsByStrategy(
                 scoredCandidates,
                 participantContext,
-                FilterStrategy.DISLIKED_EXCLUDED
+                FilterStrategy.DISLIKED_EXCLUDED,
+                topKSize
         );
 
         if (primaryResults.isEmpty()) {
@@ -427,9 +439,9 @@ public class RecommendationProcessor {
     private List<ScoredRestaurant> selectTopRestaurantsByStrategy(
             List<CategoryScoredRestaurant> scoredByCategory,
             RecommendationParticipantContext participantContext,
-            FilterStrategy strategy
+            FilterStrategy strategy,
+            int topKSize
     ) {
-        int topKSize = scoringPolicy.candidate().topKSize();
         List<CategoryScoredRestaurant> baseCandidates = applyNoDislikePreferredFilter(
                 scoredByCategory,
                 participantContext,

--- a/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
+++ b/apps/domain/src/main/java/com/yogieat/recommend/service/RecommendationProcessor.java
@@ -139,7 +139,7 @@ public class RecommendationProcessor {
         return calculateRecommendations(gatheringId, region, excludedRestaurantIds, scoringPolicy.candidate().topKSize());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public RecommendationCandidateResult calculateRecommendations(
             Long gatheringId,
             Region region,

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
@@ -2,7 +2,10 @@ package com.yogieat.recommend.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -17,10 +20,13 @@ import com.yogieat.gathering.service.GatheringService;
 import com.yogieat.participant.domain.value.DistanceRange;
 import com.yogieat.participant.service.ParticipantAnalyzer;
 import com.yogieat.participant.service.ParticipantService;
+import com.yogieat.recommend.domain.RecommendRerollHistory;
 import com.yogieat.recommend.domain.RecommendResult;
 import com.yogieat.recommend.domain.result.RecommendResultData;
 import com.yogieat.recommend.domain.value.CategoryAggregation;
+import com.yogieat.recommend.domain.value.FailureReason;
 import com.yogieat.recommend.domain.value.RecommendStatus;
+import com.yogieat.recommend.domain.value.ScoredRestaurant;
 import com.yogieat.restaurant.domain.Restaurant;
 import com.yogieat.restaurant.service.RestaurantService;
 import com.yogieat.util.LockManager;
@@ -28,6 +34,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -127,6 +134,261 @@ class RecommendResultFacadeTest {
         assertThat(result.averageAgreementRate()).isEqualTo(35.0);
         verify(restaurantService).findByIds(List.of(101L));
         verifyNoInteractions(recommendRerollHistoryService);
+    }
+
+    @Test
+    @DisplayName("v2 조회: 추천 결과가 없으면 status=null, 빈 랭킹을 반환한다")
+    void getRecommendResultsV2_ShouldReturnEmpty_WhenNoResults() {
+        Gathering gathering = gathering(1L, "key");
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(List.of());
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.status()).isNull();
+        assertThat(result.rankings()).isEmpty();
+        verifyNoInteractions(recommendRerollHistoryService, lockManager);
+    }
+
+    @Test
+    @DisplayName("v2 조회: 첫 번째 결과가 PENDING이면 status=PENDING, 빈 랭킹을 반환한다")
+    void getRecommendResultsV2_ShouldReturnPending_WhenFirstResultIsPending() {
+        Gathering gathering = gathering(1L, "key");
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(List.of(
+                RecommendResult.Create.of(1L, 101L, 0.0, RecommendStatus.PENDING, 1, 0.0, null)
+        ));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.status()).isEqualTo(RecommendStatus.PENDING);
+        assertThat(result.rankings()).isEmpty();
+        verifyNoInteractions(recommendRerollHistoryService, lockManager);
+    }
+
+    @Test
+    @DisplayName("v2 조회: reroll 이력이 이미 있으면 락 없이 원본+reroll 결과를 합쳐 반환한다")
+    void getRecommendResultsV2_ShouldReturnCachedReroll_WithoutLock() {
+        Gathering gathering = gathering(1L, "key");
+        List<RecommendResult> originalResults = List.of(
+                RecommendResult.Create.of(1L, 101L, 80.0, RecommendStatus.COMPLETED, 1, 4.0, "원본1"),
+                RecommendResult.Create.of(1L, 102L, 60.0, RecommendStatus.COMPLETED, 2, 3.8, "원본2"),
+                RecommendResult.Create.of(1L, 103L, 50.0, RecommendStatus.COMPLETED, 3, 3.5, "원본3")
+        );
+        List<RecommendRerollHistory.Result> cachedReroll = List.of(
+                RecommendRerollHistory.Result.of(1, 201L, 40.0, "reroll1"),
+                RecommendRerollHistory.Result.of(2, 202L, 30.0, "reroll2")
+        );
+        RecommendRerollHistory history = new RecommendRerollHistory(
+                10L, 1L, List.of(101L, 102L, 103L), cachedReroll, LocalDateTime.now()
+        );
+
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(originalResults);
+        when(participantService.getByGatheringId(1L)).thenReturn(List.of());
+        when(participantAnalyzer.aggregateCategoryPreferences(List.of())).thenReturn(CategoryAggregation.of(Map.of(), Map.of()));
+        when(participantAnalyzer.aggregateDistanceRanges(List.of())).thenReturn(Map.of());
+        when(restaurantService.findByIds(List.of(101L, 102L, 103L))).thenReturn(List.of(
+                restaurant(101L, 1L, "원본식당1"),
+                restaurant(102L, 1L, "원본식당2"),
+                restaurant(103L, 1L, "원본식당3")
+        ));
+        when(categoryService.findAll()).thenReturn(List.of(category(1L)));
+        when(participantAnalyzer.determineMajorityDistanceRange(any(), any())).thenReturn(DistanceRange.ANY);
+        when(recommendRerollHistoryService.findLatestByGatheringId(1L)).thenReturn(Optional.of(history));
+        when(restaurantService.findByIds(List.of(201L, 202L))).thenReturn(List.of(
+                restaurant(201L, 1L, "reroll식당1"),
+                restaurant(202L, 1L, "reroll식당2")
+        ));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.status()).isEqualTo(RecommendStatus.COMPLETED);
+        assertThat(result.rankings()).hasSize(5);
+        assertThat(result.rankings()).extracting(RecommendResultData.Ranking::rank)
+                .containsExactly(1, 2, 3, 4, 5);
+        assertThat(result.rankings().get(3).restaurantId()).isEqualTo(201L);
+        assertThat(result.rankings().get(4).restaurantId()).isEqualTo(202L);
+        verify(lockManager, never()).executeWithLock(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("v2 조회: reroll 이력 없으면 락 내에서 계산하고 저장한 뒤 반환한다")
+    @SuppressWarnings("unchecked")
+    void getRecommendResultsV2_ShouldCalculateAndSaveReroll_WhenNoCachedHistory() {
+        Gathering gathering = gathering(1L, "key");
+        List<RecommendResult> originalResults = List.of(
+                RecommendResult.Create.of(1L, 101L, 70.0, RecommendStatus.COMPLETED, 1, 4.0, "원본1"),
+                RecommendResult.Create.of(1L, 102L, 60.0, RecommendStatus.COMPLETED, 2, 3.8, "원본2"),
+                RecommendResult.Create.of(1L, 103L, 50.0, RecommendStatus.COMPLETED, 3, 3.5, "원본3")
+        );
+        Restaurant rerollRestaurant = restaurant(201L, 1L, "재추천식당1");
+        ScoredRestaurant scoredRestaurant = new ScoredRestaurant(rerollRestaurant, 3.5, 40.0, "재추천근거");
+
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(originalResults);
+        when(participantService.getByGatheringId(1L)).thenReturn(List.of());
+        when(participantAnalyzer.aggregateCategoryPreferences(List.of())).thenReturn(CategoryAggregation.of(Map.of(), Map.of()));
+        when(participantAnalyzer.aggregateDistanceRanges(List.of())).thenReturn(Map.of());
+        when(restaurantService.findByIds(List.of(101L, 102L, 103L))).thenReturn(List.of(
+                restaurant(101L, 1L, "원본식당1"),
+                restaurant(102L, 1L, "원본식당2"),
+                restaurant(103L, 1L, "원본식당3")
+        ));
+        when(categoryService.findAll()).thenReturn(List.of(category(1L)));
+        when(participantAnalyzer.determineMajorityDistanceRange(any(), any())).thenReturn(DistanceRange.ANY);
+        // 1차 조회: 이력 없음, 2차 조회(락 내부): 이력 없음
+        when(recommendRerollHistoryService.findLatestByGatheringId(1L)).thenReturn(Optional.empty());
+        when(lockManager.executeWithLock(anyString(), any())).thenAnswer(invocation -> {
+            LockManager.Task<List<RecommendRerollHistory.Result>> task = invocation.getArgument(1);
+            return task.execute();
+        });
+        when(recommendationProcessor.calculateRecommendations(
+                eq(1L), any(), eq(List.of(101L, 102L, 103L)), eq(6)
+        )).thenReturn(RecommendationCandidateResult.success(List.of(scoredRestaurant)));
+        when(restaurantService.findByIds(List.of(201L))).thenReturn(List.of(rerollRestaurant));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.status()).isEqualTo(RecommendStatus.COMPLETED);
+        assertThat(result.rankings()).hasSize(4);
+        assertThat(result.rankings().get(3).restaurantId()).isEqualTo(201L);
+        assertThat(result.rankings().get(3).reasonText()).isEqualTo("재추천근거");
+        verify(recommendRerollHistoryService).create(eq(1L), eq(List.of(101L, 102L, 103L)), anyList());
+    }
+
+    @Test
+    @DisplayName("v2 조회: 락 내부에서 이력이 새로 생기면 재계산 없이 내부 이력을 반환한다 (Double-Check)")
+    @SuppressWarnings("unchecked")
+    void getRecommendResultsV2_ShouldUseInnerHistory_WhenHistoryAppearsInsideLock() {
+        Gathering gathering = gathering(1L, "key");
+        List<RecommendResult> originalResults = List.of(
+                RecommendResult.Create.of(1L, 101L, 70.0, RecommendStatus.COMPLETED, 1, 4.0, "원본1")
+        );
+        List<RecommendRerollHistory.Result> innerReroll = List.of(
+                RecommendRerollHistory.Result.of(1, 301L, 35.0, "내부이력reroll")
+        );
+        RecommendRerollHistory innerHistory = new RecommendRerollHistory(
+                20L, 1L, List.of(101L), innerReroll, LocalDateTime.now()
+        );
+
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(originalResults);
+        when(participantService.getByGatheringId(1L)).thenReturn(List.of());
+        when(participantAnalyzer.aggregateCategoryPreferences(List.of())).thenReturn(CategoryAggregation.of(Map.of(), Map.of()));
+        when(participantAnalyzer.aggregateDistanceRanges(List.of())).thenReturn(Map.of());
+        when(restaurantService.findByIds(List.of(101L))).thenReturn(List.of(restaurant(101L, 1L, "원본식당1")));
+        when(categoryService.findAll()).thenReturn(List.of(category(1L)));
+        when(participantAnalyzer.determineMajorityDistanceRange(any(), any())).thenReturn(DistanceRange.ANY);
+        // 1차 조회: 이력 없음, 2차 조회(락 내부): 이력 있음
+        when(recommendRerollHistoryService.findLatestByGatheringId(1L))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(innerHistory));
+        when(lockManager.executeWithLock(anyString(), any())).thenAnswer(invocation -> {
+            LockManager.Task<List<RecommendRerollHistory.Result>> task = invocation.getArgument(1);
+            return task.execute();
+        });
+        when(restaurantService.findByIds(List.of(301L))).thenReturn(List.of(restaurant(301L, 1L, "내부이력식당")));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.rankings()).hasSize(2);
+        assertThat(result.rankings().get(1).restaurantId()).isEqualTo(301L);
+        verify(recommendationProcessor, never()).calculateRecommendations(any(), any(), any(), any(Integer.class));
+        verify(recommendRerollHistoryService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("v2 조회: reroll 계산이 실패하면 원본 결과만 반환한다")
+    @SuppressWarnings("unchecked")
+    void getRecommendResultsV2_ShouldReturnOnlyOriginal_WhenRerollCalculationFails() {
+        Gathering gathering = gathering(1L, "key");
+        List<RecommendResult> originalResults = List.of(
+                RecommendResult.Create.of(1L, 101L, 70.0, RecommendStatus.COMPLETED, 1, 4.0, "원본1"),
+                RecommendResult.Create.of(1L, 102L, 60.0, RecommendStatus.COMPLETED, 2, 3.8, "원본2"),
+                RecommendResult.Create.of(1L, 103L, 50.0, RecommendStatus.COMPLETED, 3, 3.5, "원본3")
+        );
+
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(originalResults);
+        when(participantService.getByGatheringId(1L)).thenReturn(List.of());
+        when(participantAnalyzer.aggregateCategoryPreferences(List.of())).thenReturn(CategoryAggregation.of(Map.of(), Map.of()));
+        when(participantAnalyzer.aggregateDistanceRanges(List.of())).thenReturn(Map.of());
+        when(restaurantService.findByIds(List.of(101L, 102L, 103L))).thenReturn(List.of(
+                restaurant(101L, 1L, "원본식당1"),
+                restaurant(102L, 1L, "원본식당2"),
+                restaurant(103L, 1L, "원본식당3")
+        ));
+        when(categoryService.findAll()).thenReturn(List.of(category(1L)));
+        when(participantAnalyzer.determineMajorityDistanceRange(any(), any())).thenReturn(DistanceRange.ANY);
+        when(recommendRerollHistoryService.findLatestByGatheringId(1L)).thenReturn(Optional.empty());
+        when(lockManager.executeWithLock(anyString(), any())).thenAnswer(invocation -> {
+            LockManager.Task<List<RecommendRerollHistory.Result>> task = invocation.getArgument(1);
+            return task.execute();
+        });
+        when(recommendationProcessor.calculateRecommendations(any(), any(), any(), any(Integer.class)))
+                .thenReturn(RecommendationCandidateResult.failure(FailureReason.NO_RESTAURANTS, "후보 없음"));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.status()).isEqualTo(RecommendStatus.COMPLETED);
+        assertThat(result.rankings()).hasSize(3);
+        assertThat(result.rankings()).extracting(RecommendResultData.Ranking::restaurantId)
+                .containsExactly(101L, 102L, 103L);
+        verify(recommendRerollHistoryService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("v2 조회: reroll 음식점이 DB에 없으면 해당 항목을 건너뛴다")
+    @SuppressWarnings("unchecked")
+    void getRecommendResultsV2_ShouldSkipMissingRerollRestaurant_WhenNotFoundInDb() {
+        Gathering gathering = gathering(1L, "key");
+        List<RecommendResult> originalResults = List.of(
+                RecommendResult.Create.of(1L, 101L, 70.0, RecommendStatus.COMPLETED, 1, 4.0, "원본1")
+        );
+        List<RecommendRerollHistory.Result> cachedReroll = List.of(
+                RecommendRerollHistory.Result.of(1, 201L, 40.0, "존재하는reroll"),
+                RecommendRerollHistory.Result.of(2, 999L, 10.0, "없는음식점reroll")
+        );
+        RecommendRerollHistory history = new RecommendRerollHistory(
+                10L, 1L, List.of(101L), cachedReroll, LocalDateTime.now()
+        );
+
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(originalResults);
+        when(participantService.getByGatheringId(1L)).thenReturn(List.of());
+        when(participantAnalyzer.aggregateCategoryPreferences(List.of())).thenReturn(CategoryAggregation.of(Map.of(), Map.of()));
+        when(participantAnalyzer.aggregateDistanceRanges(List.of())).thenReturn(Map.of());
+        when(restaurantService.findByIds(List.of(101L))).thenReturn(List.of(restaurant(101L, 1L, "원본식당1")));
+        when(categoryService.findAll()).thenReturn(List.of(category(1L)));
+        when(participantAnalyzer.determineMajorityDistanceRange(any(), any())).thenReturn(DistanceRange.ANY);
+        when(recommendRerollHistoryService.findLatestByGatheringId(1L)).thenReturn(Optional.of(history));
+        // 201L만 DB에 존재, 999L은 없음
+        when(restaurantService.findByIds(List.of(201L, 999L))).thenReturn(List.of(restaurant(201L, 1L, "reroll식당")));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.rankings()).hasSize(2);
+        assertThat(result.rankings().get(1).restaurantId()).isEqualTo(201L);
+    }
+
+    private Gathering gathering(Long id, String accessKey) {
+        return new Gathering(
+                id,
+                accessKey,
+                "모임",
+                LocalDate.of(2026, 3, 20),
+                null,
+                Region.fromString("GANGNAM"),
+                4,
+                null,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    private Category category(Long id) {
+        return new Category(id, LargeCategory.KOREAN, "한식", LocalDateTime.now());
     }
 
     private Restaurant restaurant(Long id, Long categoryId, String name) {

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendResultFacadeTest.java
@@ -137,6 +137,38 @@ class RecommendResultFacadeTest {
     }
 
     @Test
+    @DisplayName("FAILED 상태이면 status=FAILED, 빈 랭킹을 반환한다 (restaurantId=null로 인한 예외 방지)")
+    void getRecommendResults_ShouldReturnFailed_WhenFirstResultIsFailed() {
+        Gathering gathering = gathering(1L, "access-key");
+        when(gatheringService.getGatheringByAccessKey("access-key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(List.of(
+                RecommendResult.Create.of(1L, null, 0.0, RecommendStatus.FAILED, null, 0.0, null)
+        ));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResults("access-key");
+
+        assertThat(result.status()).isEqualTo(RecommendStatus.FAILED);
+        assertThat(result.rankings()).isEmpty();
+        verifyNoInteractions(restaurantService, participantService);
+    }
+
+    @Test
+    @DisplayName("v2 조회: FAILED 상태이면 status=FAILED, 빈 랭킹을 반환한다 (restaurantId=null로 인한 예외 방지)")
+    void getRecommendResultsV2_ShouldReturnFailed_WhenFirstResultIsFailed() {
+        Gathering gathering = gathering(1L, "key");
+        when(gatheringService.getGatheringByAccessKey("key")).thenReturn(gathering);
+        when(recommendResultService.findByGatheringId(1L)).thenReturn(List.of(
+                RecommendResult.Create.of(1L, null, 0.0, RecommendStatus.FAILED, null, 0.0, null)
+        ));
+
+        RecommendResultData.Get result = recommendResultFacade.getRecommendResultsV2("key");
+
+        assertThat(result.status()).isEqualTo(RecommendStatus.FAILED);
+        assertThat(result.rankings()).isEmpty();
+        verifyNoInteractions(restaurantService, participantService, lockManager);
+    }
+
+    @Test
     @DisplayName("v2 조회: 추천 결과가 없으면 status=null, 빈 랭킹을 반환한다")
     void getRecommendResultsV2_ShouldReturnEmpty_WhenNoResults() {
         Gathering gathering = gathering(1L, "key");

--- a/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
+++ b/apps/domain/src/test/java/com/yogieat/recommend/service/RecommendationProcessorTest.java
@@ -594,6 +594,83 @@ class RecommendationProcessorTest {
         assertThat(restaurantIdsByRank(savedRecommendationBatches.get(0))).containsExactly(101L, 102L, 201L);
     }
 
+    @Test
+    @DisplayName("topKSize를 6으로 지정하면 최대 6개의 후보 맛집을 반환한다")
+    void returnsUpToTopKRestaurants_when_topKSizeIsSpecified() {
+        Long gatheringId = 61L;
+        Region region = gangnam();
+        int requestedTopK = 6;
+
+        List<Participant> participants = List.of(
+                participant(1L, gatheringId, DistanceRange.ANY, "한식", null),
+                participant(2L, gatheringId, DistanceRange.ANY, "한식", null)
+        );
+        List<Category> categories = List.of(category(1L, LargeCategory.KOREAN));
+        List<Restaurant> restaurants = List.of(
+                restaurant(101L, 1L, "한식A", 4.9, point(127.0276, 37.4979), 30),
+                restaurant(102L, 1L, "한식B", 4.8, point(127.0277, 37.4978), 28),
+                restaurant(103L, 1L, "한식C", 4.7, point(127.0278, 37.4977), 25),
+                restaurant(104L, 1L, "한식D", 4.6, point(127.0279, 37.4976), 22),
+                restaurant(105L, 1L, "한식E", 4.5, point(127.0280, 37.4975), 20),
+                restaurant(106L, 1L, "한식F", 4.4, point(127.0281, 37.4974), 18)
+        );
+
+        when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
+        when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
+        when(categoryService.findAll()).thenReturn(categories);
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
+                .thenReturn(restaurants);
+
+        RecommendationCandidateResult result = recommendationProcessor.calculateRecommendations(
+                gatheringId,
+                region,
+                List.of(),
+                requestedTopK
+        );
+
+        assertThat(result.failed()).isFalse();
+        assertThat(result.restaurants()).hasSize(requestedTopK);
+        assertThat(result.restaurants())
+                .extracting(scored -> scored.restaurant().id())
+                .containsExactly(101L, 102L, 103L, 104L, 105L, 106L);
+    }
+
+    @Test
+    @DisplayName("topKSize를 6으로 지정해도 후보가 4개뿐이면 4개만 반환한다")
+    void returnsLessRestaurantsThanTopKSize_when_candidatesAreInsufficient() {
+        Long gatheringId = 62L;
+        Region region = gangnam();
+        int requestedTopK = 6;
+
+        List<Participant> participants = List.of(
+                participant(1L, gatheringId, DistanceRange.ANY, "한식", null),
+                participant(2L, gatheringId, DistanceRange.ANY, "한식", null)
+        );
+        List<Category> categories = List.of(category(1L, LargeCategory.KOREAN));
+        List<Restaurant> restaurants = List.of(
+                restaurant(101L, 1L, "한식A", 4.9, point(127.0276, 37.4979), 30),
+                restaurant(102L, 1L, "한식B", 4.7, point(127.0277, 37.4978), 25),
+                restaurant(103L, 1L, "한식C", 4.5, point(127.0278, 37.4977), 20),
+                restaurant(104L, 1L, "한식D", 4.3, point(127.0279, 37.4976), 15)
+        );
+
+        when(gatheringRepository.findById(gatheringId)).thenReturn(Optional.empty());
+        when(participantRepository.findByGatheringId(gatheringId)).thenReturn(participants);
+        when(categoryService.findAll()).thenReturn(categories);
+        when(restaurantRepository.findRecommendationCandidates(eq(region), anyCollection(), any(), anyCollection(), any()))
+                .thenReturn(restaurants);
+
+        RecommendationCandidateResult result = recommendationProcessor.calculateRecommendations(
+                gatheringId,
+                region,
+                List.of(),
+                requestedTopK
+        );
+
+        assertThat(result.failed()).isFalse();
+        assertThat(result.restaurants()).hasSize(4);
+    }
+
     private RecommendResult findRank(List<RecommendResult> results, int rank) {
         return results.stream()
                 .filter(result -> result.rank() == rank)

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/recommend/RecommendRerollHistoryCoreRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/recommend/RecommendRerollHistoryCoreRepository.java
@@ -2,6 +2,7 @@ package com.yogieat.datasource.db.core.recommend;
 
 import com.yogieat.recommend.domain.RecommendRerollHistory;
 import com.yogieat.recommend.service.RecommendRerollHistoryRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +17,12 @@ public class RecommendRerollHistoryCoreRepository implements RecommendRerollHist
         RecommendRerollHistoryEntity savedEntity =
                 recommendRerollHistoryJpaRepository.save(RecommendRerollHistoryEntity.from(recommendRerollHistory));
         return savedEntity.toDomain();
+    }
+
+    @Override
+    public Optional<RecommendRerollHistory> findLatestByGatheringId(Long gatheringId) {
+        return recommendRerollHistoryJpaRepository
+                .findTopByGatheringIdOrderByIdDesc(gatheringId)
+                .map(RecommendRerollHistoryEntity::toDomain);
     }
 }

--- a/storage/db-core/src/main/java/com/yogieat/datasource/db/core/recommend/RecommendRerollHistoryJpaRepository.java
+++ b/storage/db-core/src/main/java/com/yogieat/datasource/db/core/recommend/RecommendRerollHistoryJpaRepository.java
@@ -1,6 +1,8 @@
 package com.yogieat.datasource.db.core.recommend;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecommendRerollHistoryJpaRepository extends JpaRepository<RecommendRerollHistoryEntity, Long> {
+    Optional<RecommendRerollHistoryEntity> findTopByGatheringIdOrderByIdDesc(Long gatheringId);
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #180

## 📌 작업 내용

- `GET /api/v2/recommend-results/{accessKey}` 엔드포인트 추가
  - v1은 추천 결과(1~3위)만 반환하던 것을, v2는 reroll 후보까지 포함해 단일 리스트(최대 9개)로 반환
  - reroll 이력(`RecommendRerollHistory`)이 있으면 재사용, 없으면 계산 후 저장
  - 응답에 모임 정보, 카테고리 선호도/불호 집계, 거리 범위 집계, 평균 의견 일치율 포함
  - reroll 후보 계산 실패 시 예외를 전파하지 않고 기존 추천 결과(1~3위)만 반환

- `RecommendationProcessor` 리팩토링
  - `topKSize`를 `scoringPolicy`에서 고정으로 읽던 방식을 파라미터로 외부 주입하도록 변경
  - v2에서 reroll 후보를 가변 개수(`9 - 추천결과수`)로 요청할 수 있도록 `calculateRecommendations` 오버로드 추가
  - `top3` → `topRestaurants` 변수명 정리 (`topKSize`가 파라미터화되어 3이 아닌 값도 담길 수 있게 되어 수정)

- `RecommendResultController` → `RecommendResultV1Controller` 리네임
  - v2 컨트롤러 도입에 따라 기존 v1을 명시적으로 구분
  - 테스트 클래스 및 Swagger `@Tag` 설명도 동일하게 업데이트

- PostgreSQL 드라이버 런타임 의존성 추가 (`apps/api/build.gradle`)

## 📝 참고

- v1 API(`/api/v1/recommend-results`)는 그대로 유지

## 💬 리뷰 요구사항(선택)

-
